### PR TITLE
Zzma/add rlpx devp2p loggin

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -23,8 +23,10 @@ import (
 	"math/rand"
 	"reflect"
 
+	"encoding/json"
 	"github.com/teamnsrg/go-ethereum/common/hexutil"
 	"github.com/teamnsrg/go-ethereum/crypto/sha3"
+	"github.com/teamnsrg/go-ethereum/log"
 )
 
 const (
@@ -242,4 +244,12 @@ func (a *UnprefixedAddress) UnmarshalText(input []byte) error {
 // MarshalText encodes the address as hex.
 func (a UnprefixedAddress) MarshalText() ([]byte, error) {
 	return []byte(hex.EncodeToString(a[:])), nil
+}
+
+func MarshalObj(obj interface{}) string {
+	j, err := json.Marshal(obj)
+	if err != nil {
+		log.Crit(err.Error())
+	}
+	return string(j)
 }

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -85,6 +85,10 @@ type Header struct {
 	Nonce       BlockNonce     `json:"nonce"            gencodec:"required"`
 }
 
+func (h *Header) GoString() string {
+	return common.MarshalObj(h)
+}
+
 // field type overrides for gencodec
 type headerMarshaling struct {
 	Difficulty *hexutil.Big

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -189,7 +189,7 @@ func (pm *ProtocolManager) removePeer(id string) {
 	if peer == nil {
 		return
 	}
-	log.Proto("Removing Ethereum peer", "peer", id)
+	log.Proto("Removing Ethereum peer", "peer", peer.ID())
 
 	// Unregister the peer from the downloader and Ethereum peer set
 	pm.downloader.UnregisterPeer(id)
@@ -254,7 +254,7 @@ func (pm *ProtocolManager) handle(p *peer) error {
 	if pm.peers.Len() >= pm.maxPeers {
 		return p2p.DiscTooManyPeers
 	}
-	p.Log().Proto("Ethereum peer connected", "name", p.Name(), "nodeID", p.id)
+	p.Log().Proto("Ethereum peer connected", "name", p.Name(), "nodeID", p.ID())
 
 	// Execute the Ethereum handshake
 	td, head, genesis := pm.blockchain.Status()
@@ -335,7 +335,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", &query, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", &query, "size", msg.Size, "peer", p.ID())
 
 		hashMode := query.Origin.Hash != (common.Hash{})
 
@@ -416,7 +416,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", headers, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", headers, "size", msg.Size, "peer", p.ID())
 
 		// If no headers were received, but we're expending a DAO fork check, maybe it's that
 		if len(headers) == 0 && p.forkDrop != nil {
@@ -472,7 +472,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", *msgStream, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", *msgStream, "size", msg.Size, "peer", p.ID())
 
 		// Gather blocks until the fetch or network limits is reached
 		var (
@@ -502,7 +502,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
 
 		// Deliver them all to the downloader for queuing
 		trasactions := make([][]*types.Transaction, len(request))
@@ -531,7 +531,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", msgStream, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", msgStream, "size", msg.Size, "peer", p.ID())
 
 		// Gather state data until the fetch or network limits is reached
 		var (
@@ -561,7 +561,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
 
 		// Deliver all to the downloader
 		if err := pm.downloader.DeliverNodeData(p.id, data); err != nil {
@@ -575,7 +575,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", *msgStream, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", *msgStream, "size", msg.Size, "peer", p.ID())
 
 		// Gather state data until the fetch or network limits is reached
 		var (
@@ -614,7 +614,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
 
 		// Deliver all to the downloader
 		if err := pm.downloader.DeliverReceipts(p.id, receipts); err != nil {
@@ -627,7 +627,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", &announces, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", &announces, "size", msg.Size, "peer", p.ID())
 
 		// Mark the hashes as present at the remote node
 		for _, block := range announces {
@@ -651,7 +651,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", request, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", request, "size", msg.Size, "peer", p.ID())
 
 		request.Block.ReceivedAt = msg.ReceivedAt
 		request.Block.ReceivedFrom = p
@@ -690,7 +690,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", txs, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", txs, "size", msg.Size, "peer", p.ID())
 
 		for i, tx := range txs {
 			// Validate and mark the remote transaction

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -335,7 +335,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", query, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", &query, "size", msg.Size)
 
 		hashMode := query.Origin.Hash != (common.Hash{})
 
@@ -502,7 +502,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", request, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size)
 
 		// Deliver them all to the downloader for queuing
 		trasactions := make([][]*types.Transaction, len(request))
@@ -561,7 +561,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", data, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size)
 
 		// Deliver all to the downloader
 		if err := pm.downloader.DeliverNodeData(p.id, data); err != nil {
@@ -614,7 +614,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", receipts, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size)
 
 		// Deliver all to the downloader
 		if err := pm.downloader.DeliverReceipts(p.id, receipts); err != nil {
@@ -627,7 +627,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", announces, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", &announces, "size", msg.Size)
 
 		// Mark the hashes as present at the remote node
 		for _, block := range announces {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -189,7 +189,7 @@ func (pm *ProtocolManager) removePeer(id string) {
 	if peer == nil {
 		return
 	}
-	log.Debug("Removing Ethereum peer", "peer", id)
+	log.Proto("Removing Ethereum peer", "peer", id)
 
 	// Unregister the peer from the downloader and Ethereum peer set
 	pm.downloader.UnregisterPeer(id)
@@ -254,7 +254,7 @@ func (pm *ProtocolManager) handle(p *peer) error {
 	if pm.peers.Len() >= pm.maxPeers {
 		return p2p.DiscTooManyPeers
 	}
-	p.Log().Debug("Ethereum peer connected", "name", p.Name())
+	p.Log().Proto("Ethereum peer connected", "name", p.Name(), "nodeID", p.id)
 
 	// Execute the Ethereum handshake
 	td, head, genesis := pm.blockchain.Status()
@@ -472,7 +472,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", msgStream, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", *msgStream, "size", msg.Size)
 
 		// Gather blocks until the fetch or network limits is reached
 		var (
@@ -575,7 +575,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", msgStream, "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", *msgStream, "size", msg.Size)
 
 		// Gather state data until the fetch or network limits is reached
 		var (

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -472,7 +472,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", msgStream, "size", msg.Size)
 
 		// Gather blocks until the fetch or network limits is reached
 		var (
@@ -531,7 +531,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", msgStream, "size", msg.Size)
 
 		// Gather state data until the fetch or network limits is reached
 		var (
@@ -575,7 +575,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "size", msg.Size)
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", msgStream, "size", msg.Size)
 
 		// Gather state data until the fetch or network limits is reached
 		var (

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -334,6 +334,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&query); err != nil {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
+
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", query, "size", msg.Size)
+
 		hashMode := query.Origin.Hash != (common.Hash{})
 
 		// Gather headers until the fetch or network limits is reached
@@ -412,6 +415,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&headers); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
+
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", headers, "size", msg.Size)
+
 		// If no headers were received, but we're expending a DAO fork check, maybe it's that
 		if len(headers) == 0 && p.forkDrop != nil {
 			// Possibly an empty reply to the fork header checks, sanity check TDs
@@ -465,6 +471,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if _, err := msgStream.List(); err != nil {
 			return err
 		}
+
+		log.Proto("<<"+ethCodeToString[msg.Code], "size", msg.Size)
+
 		// Gather blocks until the fetch or network limits is reached
 		var (
 			hash   common.Hash
@@ -492,6 +501,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&request); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
+
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", request, "size", msg.Size)
+
 		// Deliver them all to the downloader for queuing
 		trasactions := make([][]*types.Transaction, len(request))
 		uncles := make([][]*types.Header, len(request))
@@ -518,6 +530,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if _, err := msgStream.List(); err != nil {
 			return err
 		}
+
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "size", msg.Size)
+
 		// Gather state data until the fetch or network limits is reached
 		var (
 			hash  common.Hash
@@ -545,6 +560,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&data); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
+
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", data, "size", msg.Size)
+
 		// Deliver all to the downloader
 		if err := pm.downloader.DeliverNodeData(p.id, data); err != nil {
 			log.Debug("Failed to deliver node state data", "err", err)
@@ -556,6 +574,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if _, err := msgStream.List(); err != nil {
 			return err
 		}
+
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "size", msg.Size)
+
 		// Gather state data until the fetch or network limits is reached
 		var (
 			hash     common.Hash
@@ -592,6 +613,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&receipts); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
+
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", receipts, "size", msg.Size)
+
 		// Deliver all to the downloader
 		if err := pm.downloader.DeliverReceipts(p.id, receipts); err != nil {
 			log.Debug("Failed to deliver receipts", "err", err)
@@ -602,6 +626,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&announces); err != nil {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
+
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", announces, "size", msg.Size)
+
 		// Mark the hashes as present at the remote node
 		for _, block := range announces {
 			p.MarkBlock(block.Hash)
@@ -623,6 +650,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&request); err != nil {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
+
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", request, "size", msg.Size)
+
 		request.Block.ReceivedAt = msg.ReceivedAt
 		request.Block.ReceivedFrom = p
 
@@ -659,6 +689,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&txs); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
+
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", txs, "size", msg.Size)
+
 		for i, tx := range txs {
 			// Validate and mark the remote transaction
 			if tx == nil {

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -136,7 +136,7 @@ func (p *peer) SendTransactions(txs types.Transactions) error {
 	for _, tx := range txs {
 		p.knownTxs.Add(tx.Hash())
 	}
-	return p2p.SendEthSubproto(p.rw, TxMsg, txs)
+	return p2p.SendEthSubproto(p.rw, TxMsg, txs, p.ID())
 }
 
 // SendNewBlockHashes announces the availability of a number of blocks through
@@ -150,82 +150,82 @@ func (p *peer) SendNewBlockHashes(hashes []common.Hash, numbers []uint64) error 
 		request[i].Hash = hashes[i]
 		request[i].Number = numbers[i]
 	}
-	return p2p.SendEthSubproto(p.rw, NewBlockHashesMsg, request)
+	return p2p.SendEthSubproto(p.rw, NewBlockHashesMsg, request, p.ID())
 }
 
 // SendNewBlock propagates an entire block to a remote peer.
 func (p *peer) SendNewBlock(block *types.Block, td *big.Int) error {
 	p.knownBlocks.Add(block.Hash())
-	return p2p.SendEthSubproto(p.rw, NewBlockMsg, []interface{}{block, td})
+	return p2p.SendEthSubproto(p.rw, NewBlockMsg, []interface{}{block, td}, p.ID())
 }
 
 // SendBlockHeaders sends a batch of block headers to the remote peer.
 func (p *peer) SendBlockHeaders(headers []*types.Header) error {
-	return p2p.SendEthSubproto(p.rw, BlockHeadersMsg, headers)
+	return p2p.SendEthSubproto(p.rw, BlockHeadersMsg, headers, p.ID())
 }
 
 // SendBlockBodies sends a batch of block contents to the remote peer.
 func (p *peer) SendBlockBodies(bodies []*blockBody) error {
-	return p2p.SendEthSubproto(p.rw, BlockBodiesMsg, blockBodiesData(bodies))
+	return p2p.SendEthSubproto(p.rw, BlockBodiesMsg, blockBodiesData(bodies), p.ID())
 }
 
 // SendBlockBodiesRLP sends a batch of block contents to the remote peer from
 // an already RLP encoded format.
 func (p *peer) SendBlockBodiesRLP(bodies []rlp.RawValue) error {
-	return p2p.SendEthSubproto(p.rw, BlockBodiesMsg, bodies)
+	return p2p.SendEthSubproto(p.rw, BlockBodiesMsg, bodies, p.ID())
 }
 
 // SendNodeDataRLP sends a batch of arbitrary internal data, corresponding to the
 // hashes requested.
 func (p *peer) SendNodeData(data [][]byte) error {
-	return p2p.SendEthSubproto(p.rw, NodeDataMsg, data)
+	return p2p.SendEthSubproto(p.rw, NodeDataMsg, data, p.ID())
 }
 
 // SendReceiptsRLP sends a batch of transaction receipts, corresponding to the
 // ones requested from an already RLP encoded format.
 func (p *peer) SendReceiptsRLP(receipts []rlp.RawValue) error {
-	return p2p.SendEthSubproto(p.rw, ReceiptsMsg, receipts)
+	return p2p.SendEthSubproto(p.rw, ReceiptsMsg, receipts, p.ID())
 }
 
 // RequestOneHeader is a wrapper around the header query functions to fetch a
 // single header. It is used solely by the fetcher.
 func (p *peer) RequestOneHeader(hash common.Hash) error {
 	p.Log().Debug("Fetching single header", "hash", hash)
-	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: hash}, Amount: uint64(1), Skip: uint64(0), Reverse: false})
+	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: hash}, Amount: uint64(1), Skip: uint64(0), Reverse: false}, p.ID())
 }
 
 // RequestHeadersByHash fetches a batch of blocks' headers corresponding to the
 // specified header query, based on the hash of an origin block.
 func (p *peer) RequestHeadersByHash(origin common.Hash, amount int, skip int, reverse bool) error {
 	p.Log().Debug("Fetching batch of headers", "count", amount, "fromhash", origin, "skip", skip, "reverse", reverse)
-	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse})
+	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse}, p.ID())
 }
 
 // RequestHeadersByNumber fetches a batch of blocks' headers corresponding to the
 // specified header query, based on the number of an origin block.
 func (p *peer) RequestHeadersByNumber(origin uint64, amount int, skip int, reverse bool) error {
 	p.Log().Debug("Fetching batch of headers", "count", amount, "fromnum", origin, "skip", skip, "reverse", reverse)
-	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Number: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse})
+	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Number: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse}, p.ID())
 }
 
 // RequestBodies fetches a batch of blocks' bodies corresponding to the hashes
 // specified.
 func (p *peer) RequestBodies(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of block bodies", "count", len(hashes))
-	return p2p.SendEthSubproto(p.rw, GetBlockBodiesMsg, hashes)
+	return p2p.SendEthSubproto(p.rw, GetBlockBodiesMsg, hashes, p.ID())
 }
 
 // RequestNodeData fetches a batch of arbitrary data from a node's known state
 // data, corresponding to the specified hashes.
 func (p *peer) RequestNodeData(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of state data", "count", len(hashes))
-	return p2p.SendEthSubproto(p.rw, GetNodeDataMsg, hashes)
+	return p2p.SendEthSubproto(p.rw, GetNodeDataMsg, hashes, p.ID())
 }
 
 // RequestReceipts fetches a batch of transaction receipts from a remote node.
 func (p *peer) RequestReceipts(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of receipts", "count", len(hashes))
-	return p2p.SendEthSubproto(p.rw, GetReceiptsMsg, hashes)
+	return p2p.SendEthSubproto(p.rw, GetReceiptsMsg, hashes, p.ID())
 }
 
 // Handshake executes the eth protocol handshake, negotiating version number,
@@ -242,7 +242,7 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 			TD:              td,
 			CurrentBlock:    head,
 			GenesisBlock:    genesis,
-		})
+		}, p.ID())
 	}()
 	go func() {
 		errc <- p.readStatus(network, &status, genesis)
@@ -279,7 +279,7 @@ func (p *peer) readStatus(network uint64, status *statusData, genesis common.Has
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
 
-	p.Log().Proto("<<"+ethCodeToString[msg.Code], "obj", status, "size", msg.Size)
+	p.Log().Proto("<<"+ethCodeToString[msg.Code], "obj", status, "size", msg.Size, "peer", p.ID())
 
 	if status.GenesisBlock != genesis {
 		return errResp(ErrGenesisBlockMismatch, "%x (!= %x)", status.GenesisBlock[:8], genesis[:8])

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -278,6 +278,9 @@ func (p *peer) readStatus(network uint64, status *statusData, genesis common.Has
 	if err := msg.Decode(&status); err != nil {
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
+
+	p.Log().Proto("<<"+ethCodeToString[msg.Code], "obj", status, "size", msg.Size)
+
 	if status.GenesisBlock != genesis {
 		return errResp(ErrGenesisBlockMismatch, "%x (!= %x)", status.GenesisBlock[:8], genesis[:8])
 	}

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -145,12 +145,24 @@ type newBlockHashesData []struct {
 	Number uint64      // Number of one particular block being announced
 }
 
+func (msg newBlockHashesData) GoString() string {
+	var msgs []interface{}
+	for _, blockHash := range msg {
+		msgs = append(msgs, common.MarshalObj(blockHash))
+	}
+	return common.MarshalObj(msgs)
+}
+
 // getBlockHeadersData represents a block header query.
 type getBlockHeadersData struct {
 	Origin  hashOrNumber // Block from which to retrieve headers
 	Amount  uint64       // Maximum number of headers to retrieve
 	Skip    uint64       // Blocks to skip between consecutive headers
 	Reverse bool         // Query direction (false = rising towards latest, true = falling towards genesis)
+}
+
+func (msg *getBlockHeadersData) GoString() string {
+	return common.MarshalObj(msg)
 }
 
 // hashOrNumber is a combined field for specifying an origin block.
@@ -195,10 +207,18 @@ type newBlockData struct {
 	TD    *big.Int
 }
 
+func (msg *newBlockData) GoString() string {
+	return common.MarshalObj(msg)
+}
+
 // blockBody represents the data content of a single block.
 type blockBody struct {
 	Transactions []*types.Transaction // Transactions contained within a block
 	Uncles       []*types.Header      // Uncles contained within a block
+}
+
+func (msg *blockBody) GoString() string {
+	return common.MarshalObj(msg)
 }
 
 // blockBodiesData is the network packet for block content distribution.

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -135,6 +135,10 @@ type statusData struct {
 	GenesisBlock    common.Hash
 }
 
+func (sd *statusData) GoString() string {
+	return common.MarshalObj(sd)
+}
+
 // newBlockHashesData is the network packet for the block announcements.
 type newBlockHashesData []struct {
 	Hash   common.Hash // Hash of one particular block being announced

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -64,6 +64,24 @@ const (
 	ReceiptsMsg    = 0x10
 )
 
+var ethCodeToString = [...]string{
+	// Protocol messages belonging to eth/62
+	StatusMsg:          "ETH_STATUS",
+	NewBlockHashesMsg:  "ETH_NEW_BLOCK_HASHES",
+	TxMsg:              "ETH_TX",
+	GetBlockHeadersMsg: "ETH_GET_BLOCK_HEADERS",
+	BlockHeadersMsg:    "ETH_BLOCK_HEADERS",
+	GetBlockBodiesMsg:  "ETH_GET_BLOCK_BODIES",
+	BlockBodiesMsg:     "ETH_BLOCK_BODIES",
+	NewBlockMsg:        "ETH_NEW_BLOCK",
+
+	// Protocol messages belonging to eth/63
+	GetNodeDataMsg: "ETH_GET_NODE_DATA",
+	NodeDataMsg:    "ETH_NODE_DATA",
+	GetReceiptsMsg: "ETH_GET_RECEIPTS",
+	ReceiptsMsg:    "ETH_RECEIPTS",
+}
+
 type errCode int
 
 const (

--- a/log/logger.go
+++ b/log/logger.go
@@ -119,6 +119,7 @@ type Logger interface {
 	Warn(msg string, ctx ...interface{})
 	Error(msg string, ctx ...interface{})
 	Crit(msg string, ctx ...interface{})
+	Proto(msg string, ctx ...interface{})
 }
 
 type logger struct {
@@ -153,6 +154,10 @@ func newContext(prefix []interface{}, suffix []interface{}) []interface{} {
 	n := copy(newCtx, prefix)
 	copy(newCtx[n:], normalizedSuffix)
 	return newCtx
+}
+
+func (l *logger) Proto(msg string, ctx ...interface{}) {
+	l.write(msg, LvlCrit, ctx)
 }
 
 func (l *logger) Trace(msg string, ctx ...interface{}) {

--- a/log/logger.go
+++ b/log/logger.go
@@ -156,8 +156,16 @@ func newContext(prefix []interface{}, suffix []interface{}) []interface{} {
 	return newCtx
 }
 
+func CtxToString(ctx []interface{}) string {
+	str := ""
+	for i := 0; i < len(ctx); i += 2 {
+		str += fmt.Sprintf("|%s=%#v", ctx[i], ctx[i+1])
+	}
+	return str
+}
+
 func (l *logger) Proto(msg string, ctx ...interface{}) {
-	l.write(msg, LvlCrit, ctx)
+	l.write(msg+CtxToString(ctx), LvlCrit, nil)
 }
 
 func (l *logger) Trace(msg string, ctx ...interface{}) {

--- a/log/root.go
+++ b/log/root.go
@@ -54,6 +54,10 @@ func Error(msg string, ctx ...interface{}) {
 	root.write(msg, LvlError, ctx)
 }
 
+func Proto(msg string, ctx ...interface{}) {
+	root.write(msg, LvlCrit, ctx)
+}
+
 // Crit is a convenient alias for Root().Crit
 func Crit(msg string, ctx ...interface{}) {
 	root.write(msg, LvlCrit, ctx)

--- a/log/root.go
+++ b/log/root.go
@@ -55,7 +55,7 @@ func Error(msg string, ctx ...interface{}) {
 }
 
 func Proto(msg string, ctx ...interface{}) {
-	root.write(msg, LvlCrit, ctx)
+	root.write(msg+CtxToString(ctx), LvlCrit, nil)
 }
 
 // Crit is a convenient alias for Root().Crit

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -237,7 +237,7 @@ func (n NodeID) String() string {
 
 // The Go syntax representation of a NodeID is a call to HexID.
 func (n NodeID) GoString() string {
-	return fmt.Sprintf("discover.HexID(\"%x\")", n[:])
+	return fmt.Sprintf("%x", n[:])
 }
 
 // TerminalString returns a shortened hex string for terminal logging.

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -490,7 +490,7 @@ func (t *udp) send(toaddr *net.UDPAddr, ptype byte, req packet) error {
 		return err
 	}
 	_, err = t.conn.WriteToUDP(packet, toaddr)
-	log.Proto(">> "+req.name(), "size", len(packet), "err", err, "obj", req)
+	log.Proto(">>"+req.name(), "size", len(packet), "err", err, "obj", req)
 	return err
 }
 
@@ -545,7 +545,7 @@ func (t *udp) handlePacket(from *net.UDPAddr, buf []byte) error {
 		return err
 	}
 	err = packet.handle(t, from, fromID, hash)
-	log.Proto("<< "+packet.name(), "addr", from.String(), "size", len(buf), "err", err, "obj", packet)
+	log.Proto("<<"+packet.name(), "addr", from.String(), "size", len(buf), "err", err, "obj", packet)
 	return err
 }
 

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -490,7 +490,7 @@ func (t *udp) send(toaddr *net.UDPAddr, ptype byte, req packet) error {
 		return err
 	}
 	_, err = t.conn.WriteToUDP(packet, toaddr)
-	log.Proto(">> "+req.name(), "err", err, "obj", fmt.Sprintf("%#v", req))
+	log.Proto(">> "+req.name(), "size", len(packet), "err", err, "obj", fmt.Sprintf("%#v", req))
 	return err
 }
 
@@ -545,7 +545,7 @@ func (t *udp) handlePacket(from *net.UDPAddr, buf []byte) error {
 		return err
 	}
 	err = packet.handle(t, from, fromID, hash)
-	log.Proto("<< "+packet.name(), "addr", from, "err", err, "str", fmt.Sprintf("%#v", packet))
+	log.Proto("<< "+packet.name(), "addr", from, "size", len(buf), "err", err, "str", fmt.Sprintf("%#v", packet))
 	return err
 }
 

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -490,7 +490,7 @@ func (t *udp) send(toaddr *net.UDPAddr, ptype byte, req packet) error {
 		return err
 	}
 	_, err = t.conn.WriteToUDP(packet, toaddr)
-	log.Proto(">> "+req.name(), "size", len(packet), "err", err, "obj", fmt.Sprintf("%#v", req))
+	log.Proto(">> "+req.name(), "size", len(packet), "err", err, "obj", req)
 	return err
 }
 
@@ -545,7 +545,7 @@ func (t *udp) handlePacket(from *net.UDPAddr, buf []byte) error {
 		return err
 	}
 	err = packet.handle(t, from, fromID, hash)
-	log.Proto("<< "+packet.name(), "addr", from, "size", len(buf), "err", err, "str", fmt.Sprintf("%#v", packet))
+	log.Proto("<< "+packet.name(), "addr", from.String(), "size", len(buf), "err", err, "obj", packet)
 	return err
 }
 

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -490,7 +490,7 @@ func (t *udp) send(toaddr *net.UDPAddr, ptype byte, req packet) error {
 		return err
 	}
 	_, err = t.conn.WriteToUDP(packet, toaddr)
-	log.Trace(">> "+req.name(), "err", err, "obj", fmt.Sprintf("%#v", req))
+	log.Proto(">> "+req.name(), "err", err, "obj", fmt.Sprintf("%#v", req))
 	return err
 }
 
@@ -545,7 +545,7 @@ func (t *udp) handlePacket(from *net.UDPAddr, buf []byte) error {
 		return err
 	}
 	err = packet.handle(t, from, fromID, hash)
-	log.Trace("<< "+packet.name(), "addr", from, "err", err, "str", fmt.Sprintf("%#v", packet))
+	log.Proto("<< "+packet.name(), "addr", from, "err", err, "str", fmt.Sprintf("%#v", packet))
 	return err
 }
 

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -25,12 +25,12 @@ import (
 	"net"
 	"time"
 
+	"encoding/json"
 	"github.com/teamnsrg/go-ethereum/crypto"
 	"github.com/teamnsrg/go-ethereum/log"
 	"github.com/teamnsrg/go-ethereum/p2p/nat"
 	"github.com/teamnsrg/go-ethereum/p2p/netutil"
 	"github.com/teamnsrg/go-ethereum/rlp"
-	"encoding/json"
 )
 
 const Version = 4
@@ -60,7 +60,7 @@ const (
 
 // RPC packet types
 const (
-	pingPacket      = iota + 1 // zero is 'reserved'
+	pingPacket = iota + 1 // zero is 'reserved'
 	pongPacket
 	findnodePacket
 	neighborsPacket

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -490,7 +490,7 @@ func (t *udp) send(toaddr *net.UDPAddr, ptype byte, req packet) error {
 		return err
 	}
 	_, err = t.conn.WriteToUDP(packet, toaddr)
-	log.Proto(">>"+req.name(), "size", len(packet), "err", err, "obj", req)
+	log.Proto(">>"+req.name(), "to", toaddr.String(), "size", len(packet), "err", err, "obj", req)
 	return err
 }
 
@@ -545,7 +545,7 @@ func (t *udp) handlePacket(from *net.UDPAddr, buf []byte) error {
 		return err
 	}
 	err = packet.handle(t, from, fromID, hash)
-	log.Proto("<<"+packet.name(), "addr", from.String(), "size", len(buf), "err", err, "obj", packet)
+	log.Proto("<<"+packet.name(), "from", fromID, "size", len(buf), "err", err, "obj", packet)
 	return err
 }
 

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -27,7 +27,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"encoding/json"
 	"github.com/teamnsrg/go-ethereum/event"
+	"github.com/teamnsrg/go-ethereum/log"
 	"github.com/teamnsrg/go-ethereum/p2p/discover"
 	"github.com/teamnsrg/go-ethereum/rlp"
 )
@@ -44,6 +46,14 @@ type Msg struct {
 	Size       uint32 // size of the paylod
 	Payload    io.Reader
 	ReceivedAt time.Time
+}
+
+func (msg *Msg) GoString() string {
+	j, err := json.Marshal(msg)
+	if err != nil {
+		log.Crit(err.Error())
+	}
+	return string(j)
 }
 
 // Decode parses the RLP content of a message into

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -130,7 +130,10 @@ func SendDEVp2p(w MsgWriter, msgcode uint64, data interface{}) error {
 	}
 
 	msgType := devp2pCodeToString[msgcode]
-	log.Proto(">>"+msgType, "obj", data, "size", size)
+	if msgcode == discMsg {
+		data = discReasonToString[data.(DiscReason)]
+	}
+	log.Proto(">>"+msgType, "obj", data, "size", uint32(size))
 	return w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 }
 

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -111,15 +111,27 @@ func Send(w MsgWriter, msgcode uint64, data interface{}) error {
 }
 
 func SendEthSubproto(w MsgWriter, msgcode uint64, data interface{}) error {
+	size, r, err := rlp.EncodeToReader(data)
+
+	if err != nil {
+		return err
+	}
+
 	msgType := ethCodeToString[msgcode]
-	log.Proto(">>"+msgType, "obj", data)
-	return Send(w, msgcode, data)
+	log.Proto(">>"+msgType, "obj", data, "size", size)
+	return w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 }
 
 func SendDEVp2p(w MsgWriter, msgcode uint64, data interface{}) error {
+	size, r, err := rlp.EncodeToReader(data)
+
+	if err != nil {
+		return err
+	}
+
 	msgType := devp2pCodeToString[msgcode]
-	log.Proto(">>"+msgType, "obj", data)
-	return Send(w, msgcode, data)
+	log.Proto(">>"+msgType, "obj", data, "size", size)
+	return w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 }
 
 // SendItems writes an RLP with the given code and data elements.

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -118,6 +118,9 @@ func SendEthSubproto(w MsgWriter, msgcode uint64, data interface{}) error {
 	}
 
 	msgType := ethCodeToString[msgcode]
+	if msgcode == 0x06 { // exclude data for BLOCK_BODIES
+		data = "<OMITTED>"
+	}
 	log.Proto(">>"+msgType, "obj", data, "size", size)
 	return w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 }

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -110,33 +110,43 @@ func Send(w MsgWriter, msgcode uint64, data interface{}) error {
 	return w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 }
 
-func SendEthSubproto(w MsgWriter, msgcode uint64, data interface{}) error {
+func SendEthSubproto(w MsgWriter, msgcode uint64, data interface{}, peers ...discover.NodeID) error {
 	size, r, err := rlp.EncodeToReader(data)
 
 	if err != nil {
 		return err
+	}
+
+	var peer discover.NodeID
+	if len(peers) == 1 {
+		peer = peers[0]
 	}
 
 	msgType := ethCodeToString[msgcode]
 	if msgcode == 0x06 { // exclude data for BLOCK_BODIES
 		data = "<OMITTED>"
 	}
-	log.Proto(">>"+msgType, "obj", data, "size", size)
+	log.Proto(">>"+msgType, "obj", data, "size", size, "peer", peer)
 	return w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 }
 
-func SendDEVp2p(w MsgWriter, msgcode uint64, data interface{}) error {
+func SendDEVp2p(w MsgWriter, msgcode uint64, data interface{}, peers ...discover.NodeID) error {
 	size, r, err := rlp.EncodeToReader(data)
 
 	if err != nil {
 		return err
 	}
 
+	var peer discover.NodeID
+	if len(peers) == 1 {
+		peer = peers[0]
+	}
+
 	msgType := devp2pCodeToString[msgcode]
 	if msgcode == discMsg {
 		data = discReasonToString[data.(DiscReason)]
 	}
-	log.Proto(">>"+msgType, "obj", data, "size", uint32(size))
+	log.Proto(">>"+msgType, "obj", data, "size", uint32(size), "peer", peer)
 	return w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 }
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -52,6 +52,33 @@ const (
 	peersMsg     = 0x05
 )
 
+var devp2pCodeToString = [...]string{
+	handshakeMsg: "DEVP2P_HELLO",
+	discMsg:      "DEVP2P_DISC",
+	pingMsg:      "DEVP2P_PING",
+	pongMsg:      "DEVP2P_PONG",
+	getPeersMsg:  "DEVP2P_GET_PEERS",
+	peersMsg:     "DEVP2P_PEERS",
+}
+
+var ethCodeToString = [...]string{
+	// Protocol messages belonging to eth/62
+	0x00: "ETH_STATUS",
+	0x01: "ETH_NEW_BLOCK_HASHES",
+	0x02: "ETH_TX",
+	0x03: "ETH_GET_BLOCK_HEADERS",
+	0x04: "ETH_BLOCK_HEADERS",
+	0x05: "ETH_GET_BLOCK_BODIES",
+	0x06: "ETH_BLOCK_BODIES",
+	0x07: "ETH_NEW_BLOCK",
+
+	// Protocol messages belonging to eth/63
+	0x0d: "ETH_GET_NODE_DATA",
+	0x0e: "ETH_NODE_DATA",
+	0x0f: "ETH_GET_RECEIPTS",
+	0x10: "ETH_RECEIPTS",
+}
+
 // protoHandshake is the RLP structure of the protocol handshake.
 type protoHandshake struct {
 	Version    uint64
@@ -230,7 +257,6 @@ loop:
 		}
 	}
 
-	p.log.Proto(">> DEVP2P_DISC", "reason", discReasonToString[reason])
 	close(p.closed)
 	p.rw.close(reason)
 	p.wg.Wait()
@@ -244,7 +270,6 @@ func (p *Peer) pingLoop() {
 	for {
 		select {
 		case <-ping.C:
-			p.log.Proto(">> DEVP2P_PING")
 			if err := SendItems(p.rw, pingMsg); err != nil {
 				p.protoErr <- err
 				return
@@ -277,7 +302,6 @@ func (p *Peer) handle(msg Msg) error {
 	case msg.Code == pingMsg:
 		p.log.Proto("<< DEVP2P_PING", "obj", msg.GoString())
 		msg.Discard()
-		p.log.Proto(">> DEVP2P_PONG")
 		go SendItems(p.rw, pongMsg)
 	case msg.Code == pongMsg:
 		p.log.Proto("<< DEVP2P_PONG", "obj", msg.GoString())

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -303,7 +303,7 @@ func (p *Peer) readLoop(errc chan<- error) {
 }
 
 func (p *Peer) handle(msg Msg) error {
-	var emptyMsgObj [0]interface{}
+	var emptyMsgObj []interface{}
 	switch {
 	case msg.Code == pingMsg:
 		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", msg.Size)

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -275,7 +275,7 @@ func (p *Peer) pingLoop() {
 	for {
 		select {
 		case <-ping.C:
-			if err := SendItems(p.rw, pingMsg); err != nil {
+			if err := SendDEVp2p(p.rw, pingMsg, make([]interface{}, 0), p.ID()); err != nil {
 				p.protoErr <- err
 				return
 			}
@@ -306,18 +306,18 @@ func (p *Peer) handle(msg Msg) error {
 	var emptyMsgObj []interface{}
 	switch {
 	case msg.Code == pingMsg:
-		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", msg.Size)
+		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", msg.Size, "peer", p.ID())
 		msg.Discard()
-		go SendItems(p.rw, pongMsg)
+		go SendDEVp2p(p.rw, pongMsg, make([]interface{}, 0), p.ID())
 	case msg.Code == pongMsg:
-		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", msg.Size)
+		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", msg.Size, "peer", p.ID())
 		msg.Discard()
 	case msg.Code == discMsg:
 		var reason [1]DiscReason
 		// This is the last message. We don't need to discard or
 		// check errors because, the connection will be closed after it.
 		rlp.Decode(msg.Payload, &reason)
-		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", discReasonToString[reason[0]], "size", msg.Size)
+		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", discReasonToString[reason[0]], "size", msg.Size, "peer", p.ID())
 		return reason[0]
 	case msg.Code < baseProtocolLength:
 		// ignore other base protocol messages

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -263,7 +263,7 @@ loop:
 	}
 
 	close(p.closed)
-	p.rw.close(reason)
+	p.rw.close(reason, p.ID())
 	p.wg.Wait()
 	return remoteRequested, err
 }

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"encoding/json"
+	"github.com/teamnsrg/go-ethereum/common"
 	"github.com/teamnsrg/go-ethereum/common/mclock"
 	"github.com/teamnsrg/go-ethereum/event"
 	"github.com/teamnsrg/go-ethereum/log"
@@ -89,6 +90,10 @@ type protoHandshake struct {
 
 	// Ignore additional fields (for forward compatibility).
 	Rest []rlp.RawValue `rlp:"tail"`
+}
+
+func (ph *protoHandshake) String() string {
+	return common.MarshalObj(ph)
 }
 
 // PeerEventType is the type of peer events emitted by a p2p.Server

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -275,16 +275,19 @@ func (p *Peer) readLoop(errc chan<- error) {
 func (p *Peer) handle(msg Msg) error {
 	switch {
 	case msg.Code == pingMsg:
-		p.log.Proto("<< DEVP2P_PING", "obj", fmt.Sprintf("%#v", msg))
+		p.log.Proto("<< DEVP2P_PING", "obj", msg.GoString())
 		msg.Discard()
 		p.log.Proto(">> DEVP2P_PONG")
 		go SendItems(p.rw, pongMsg)
+	case msg.Code == pongMsg:
+		p.log.Proto("<< DEVP2P_PONG", "obj", msg.GoString())
+		msg.Discard()
 	case msg.Code == discMsg:
 		var reason [1]DiscReason
 		// This is the last message. We don't need to discard or
 		// check errors because, the connection will be closed after it.
 		rlp.Decode(msg.Payload, &reason)
-		p.log.Proto("<< DEVP2P_DISC", "reason", discReasonToString[reason[0]], "obj", fmt.Sprintf("%#v", msg))
+		p.log.Proto("<< DEVP2P_DISC", "reason", discReasonToString[reason[0]], "obj", msg.GoString())
 		return reason[0]
 	case msg.Code < baseProtocolLength:
 		// ignore other base protocol messages

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -298,20 +298,21 @@ func (p *Peer) readLoop(errc chan<- error) {
 }
 
 func (p *Peer) handle(msg Msg) error {
+	var emptyMsgObj [0]interface{}
 	switch {
 	case msg.Code == pingMsg:
-		p.log.Proto("<< DEVP2P_PING", "obj", msg.GoString())
+		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", msg.Size)
 		msg.Discard()
 		go SendItems(p.rw, pongMsg)
 	case msg.Code == pongMsg:
-		p.log.Proto("<< DEVP2P_PONG", "obj", msg.GoString())
+		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", msg.Size)
 		msg.Discard()
 	case msg.Code == discMsg:
 		var reason [1]DiscReason
 		// This is the last message. We don't need to discard or
 		// check errors because, the connection will be closed after it.
 		rlp.Decode(msg.Payload, &reason)
-		p.log.Proto("<< DEVP2P_DISC", "reason", discReasonToString[reason[0]], "obj", msg.GoString())
+		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", discReasonToString[reason[0]], "size", msg.Size)
 		return reason[0]
 	case msg.Code < baseProtocolLength:
 		// ignore other base protocol messages

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -59,7 +59,7 @@ func testPeer(protos []Protocol) (func(), *conn, *Peer, <-chan error) {
 		errc <- err
 	}()
 
-	closer := func() { c2.close(errors.New("close func called")) }
+	closer := func() { c2.close(errors.New("close func called"), peer.ID()) }
 	return closer, c2, peer, errc
 }
 

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -40,6 +40,7 @@ import (
 	"github.com/teamnsrg/go-ethereum/crypto/ecies"
 	"github.com/teamnsrg/go-ethereum/crypto/secp256k1"
 	"github.com/teamnsrg/go-ethereum/crypto/sha3"
+	"github.com/teamnsrg/go-ethereum/log"
 	"github.com/teamnsrg/go-ethereum/p2p/discover"
 	"github.com/teamnsrg/go-ethereum/rlp"
 )
@@ -154,6 +155,7 @@ func readProtocolHandshake(rw MsgReader, our *protoHandshake) (*protoHandshake, 
 		// back otherwise. Wrap it in a string instead.
 		var reason [1]DiscReason
 		rlp.Decode(msg.Payload, &reason)
+		log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", discReasonToString[reason[0]], "size", msg.Size)
 		return nil, reason[0]
 	}
 	if msg.Code != handshakeMsg {
@@ -163,6 +165,9 @@ func readProtocolHandshake(rw MsgReader, our *protoHandshake) (*protoHandshake, 
 	if err := msg.Decode(&hs); err != nil {
 		return nil, err
 	}
+
+	log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", hs, "size", msg.Size)
+
 	if (hs.ID == discover.NodeID{}) {
 		return nil, DiscInvalidIdentity
 	}

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -166,7 +166,7 @@ func readProtocolHandshake(rw MsgReader, our *protoHandshake) (*protoHandshake, 
 		return nil, err
 	}
 
-	log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", hs, "size", msg.Size)
+	log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", &hs, "size", msg.Size)
 
 	if (hs.ID == discover.NodeID{}) {
 		return nil, DiscInvalidIdentity

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -109,7 +109,7 @@ func (t *rlpx) close(err error) {
 	if t.rw != nil {
 		if r, ok := err.(DiscReason); ok && r != DiscNetworkError {
 			t.fd.SetWriteDeadline(time.Now().Add(discWriteTimeout))
-			SendItems(t.rw, discMsg, r)
+			SendDEVp2p(t.rw, discMsg, r)
 		}
 	}
 	t.fd.Close()
@@ -125,7 +125,7 @@ func (t *rlpx) doProtoHandshake(our *protoHandshake) (their *protoHandshake, err
 	// disconnects us early with a valid reason, we should return it
 	// as the error so it can be tracked elsewhere.
 	werr := make(chan error, 1)
-	go func() { werr <- Send(t.rw, handshakeMsg, our) }()
+	go func() { werr <- SendDEVp2p(t.rw, handshakeMsg, our) }()
 	if their, err = readProtocolHandshake(t.rw, our); err != nil {
 		<-werr // make sure the write terminates too
 		return nil, err

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -55,7 +55,7 @@ const (
 	authMsgLen  = sigLen + shaLen + pubLen + shaLen + 1
 	authRespLen = pubLen + shaLen + 1
 
-	eciesOverhead = 65 /* pubkey */ + 16 /* IV */ + 32 /* MAC */
+	eciesOverhead = 65 + 16 + 32 /* pubkey + IV + MAC */
 
 	encAuthMsgLen  = authMsgLen + eciesOverhead  // size of encrypted pre-EIP-8 initiator handshake
 	encAuthRespLen = authRespLen + eciesOverhead // size of encrypted pre-EIP-8 handshake reply

--- a/p2p/rlpx_test.go
+++ b/p2p/rlpx_test.go
@@ -175,7 +175,7 @@ func TestProtocolHandshake(t *testing.T) {
 			return
 		}
 
-		phs, err := rlpx.doProtoHandshake(hs0)
+		phs, err := rlpx.doProtoHandshake(hs0, node1.ID)
 		if err != nil {
 			t.Errorf("dial side proto handshake error: %v", err)
 			return
@@ -185,7 +185,7 @@ func TestProtocolHandshake(t *testing.T) {
 			t.Errorf("dial side proto handshake mismatch:\ngot: %s\nwant: %s\n", spew.Sdump(phs), spew.Sdump(hs1))
 			return
 		}
-		rlpx.close(DiscQuitting)
+		rlpx.close(DiscQuitting, node1.ID)
 	}()
 	go func() {
 		defer wg.Done()
@@ -201,7 +201,7 @@ func TestProtocolHandshake(t *testing.T) {
 			return
 		}
 
-		phs, err := rlpx.doProtoHandshake(hs1)
+		phs, err := rlpx.doProtoHandshake(hs1, node0.ID)
 		if err != nil {
 			t.Errorf("listen side proto handshake error: %v", err)
 			return

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -705,61 +705,49 @@ func (srv *Server) SetupConn(fd net.Conn, flags connFlag, dialDest *discover.Nod
 	srv.lock.Unlock()
 	c := &conn{fd: fd, transport: srv.newTransport(fd), flags: flags, cont: make(chan error)}
 	if !running {
-		closeConnAndLog(c, nil, errServerStopped)
+		c.close(errServerStopped)
 		return
 	}
 	// Run the encryption handshake.
 	var err error
 	if c.id, err = c.doEncHandshake(srv.PrivateKey, dialDest); err != nil {
 		log.Trace("Failed RLPx handshake", "addr", c.fd.RemoteAddr(), "conn", c.flags, "err", err)
-		closeConnAndLog(c, nil, err)
+		c.close(err)
 		return
 	}
 	// For dialed connections, check that the remote public key matches.
 	clog := log.New("id", c.id, "addr", c.fd.RemoteAddr(), "conn", c.flags)
 	if dialDest != nil && c.id != dialDest.ID {
-		closeConnAndLog(c, clog, DiscUnexpectedIdentity)
+		c.close(DiscUnexpectedIdentity)
 		clog.Trace("Dialed identity mismatch", "want", c, dialDest.ID)
 		return
 	}
 	if err := srv.checkpoint(c, srv.posthandshake); err != nil {
 		clog.Trace("Rejected peer before protocol handshake", "err", err)
-		closeConnAndLog(c, clog, err)
+		c.close(err)
 		return
 	}
 	// Run the protocol handshake
-	clog.Proto(">> HELLO", "obj", fmt.Sprintf("%#v", srv.ourHandshake))
 	phs, err := c.doProtoHandshake(srv.ourHandshake)
 	clog.Proto("<< HELLO", "obj", fmt.Sprintf("%#v", phs))
 	if err != nil {
 		clog.Trace("Failed proto handshake", "err", err)
-		closeConnAndLog(c, clog, err)
+		c.close(err)
 		return
 	}
 	if phs.ID != c.id {
 		clog.Trace("Wrong devp2p handshake identity", "err", phs.ID)
-		closeConnAndLog(c, clog, DiscUnexpectedIdentity)
+		c.close(DiscUnexpectedIdentity)
 		return
 	}
 	c.caps, c.name = phs.Caps, phs.Name
 	if err := srv.checkpoint(c, srv.addpeer); err != nil {
 		clog.Trace("Rejected peer", "err", err)
-		closeConnAndLog(c, clog, err)
+		c.close(err)
 		return
 	}
 	// If the checks completed successfully, runPeer has now been
 	// launched by run.
-}
-
-func closeConnAndLog(c *conn, logger log.Logger, err error) {
-	if r, ok := err.(DiscReason); ok {
-		if logger == nil {
-			log.Proto(">> DEVP2P_DISCONNECT", "reason", discReasonToString[r])
-		} else {
-			logger.Proto(">> DEVP2P_DISCONNECT", "reason", discReasonToString[r])
-		}
-	}
-	c.close(err)
 }
 
 func truncateName(s string) string {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -729,7 +729,6 @@ func (srv *Server) SetupConn(fd net.Conn, flags connFlag, dialDest *discover.Nod
 	}
 	// Run the protocol handshake
 	phs, err := c.doProtoHandshake(srv.ourHandshake)
-	clog.Proto("<< HELLO", "obj", fmt.Sprintf("%#v", phs))
 	if err != nil {
 		clog.Trace("Failed proto handshake", "err", err)
 		c.close(err)

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -565,7 +565,7 @@ running:
 					p.events = &srv.peerFeed
 				}
 				name := truncateName(c.name)
-				log.Debug("Adding p2p peer", "id", c.id, "name", name, "addr", c.fd.RemoteAddr(), "peers", len(peers)+1)
+				log.Proto("Adding p2p peer", "id", c.id, "name", name, "addr", c.fd.RemoteAddr(), "peers", len(peers)+1)
 				peers[c.id] = p
 				go srv.runPeer(p)
 			}
@@ -580,7 +580,7 @@ running:
 		case pd := <-srv.delpeer:
 			// A peer disconnected.
 			d := common.PrettyDuration(mclock.Now() - pd.created)
-			pd.log.Debug("Removing p2p peer", "duration", d, "peers", len(peers)-1, "req", pd.requested, "err", pd.err)
+			pd.log.Proto("Removing p2p peer", "duration", d, "peers", len(peers)-1, "req", pd.requested, "err", pd.err)
 			delete(peers, pd.ID())
 		}
 	}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -206,7 +206,7 @@ type conn struct {
 type transport interface {
 	// The two handshakes.
 	doEncHandshake(prv *ecdsa.PrivateKey, dialDest *discover.Node) (discover.NodeID, error)
-	doProtoHandshake(our *protoHandshake) (*protoHandshake, error)
+	doProtoHandshake(our *protoHandshake, peer discover.NodeID) (*protoHandshake, error)
 	// The MsgReadWriter can only be used after the encryption
 	// handshake has completed. The code uses conn.id to track this
 	// by setting it to a non-nil value after the encryption handshake.
@@ -214,7 +214,7 @@ type transport interface {
 	// transports must provide Close because we use MsgPipe in some of
 	// the tests. Closing the actual network connection doesn't do
 	// anything in those tests because NsgPipe doesn't use it.
-	close(err error)
+	close(err error, peer discover.NodeID)
 }
 
 func (c *conn) String() string {
@@ -705,44 +705,44 @@ func (srv *Server) SetupConn(fd net.Conn, flags connFlag, dialDest *discover.Nod
 	srv.lock.Unlock()
 	c := &conn{fd: fd, transport: srv.newTransport(fd), flags: flags, cont: make(chan error)}
 	if !running {
-		c.close(errServerStopped)
+		c.close(errServerStopped, discover.NodeID{})
 		return
 	}
 	// Run the encryption handshake.
 	var err error
 	if c.id, err = c.doEncHandshake(srv.PrivateKey, dialDest); err != nil {
 		log.Trace("Failed RLPx handshake", "addr", c.fd.RemoteAddr(), "conn", c.flags, "err", err)
-		c.close(err)
+		c.close(err, c.id)
 		return
 	}
 	// For dialed connections, check that the remote public key matches.
 	clog := log.New("id", c.id, "addr", c.fd.RemoteAddr(), "conn", c.flags)
 	if dialDest != nil && c.id != dialDest.ID {
-		c.close(DiscUnexpectedIdentity)
+		c.close(DiscUnexpectedIdentity, c.id)
 		clog.Trace("Dialed identity mismatch", "want", c, dialDest.ID)
 		return
 	}
 	if err := srv.checkpoint(c, srv.posthandshake); err != nil {
 		clog.Trace("Rejected peer before protocol handshake", "err", err)
-		c.close(err)
+		c.close(err, c.id)
 		return
 	}
 	// Run the protocol handshake
-	phs, err := c.doProtoHandshake(srv.ourHandshake)
+	phs, err := c.doProtoHandshake(srv.ourHandshake, c.id)
 	if err != nil {
 		clog.Trace("Failed proto handshake", "err", err)
-		c.close(err)
+		c.close(err, c.id)
 		return
 	}
 	if phs.ID != c.id {
 		clog.Trace("Wrong devp2p handshake identity", "err", phs.ID)
-		c.close(DiscUnexpectedIdentity)
+		c.close(DiscUnexpectedIdentity, c.id)
 		return
 	}
 	c.caps, c.name = phs.Caps, phs.Name
 	if err := srv.checkpoint(c, srv.addpeer); err != nil {
 		clog.Trace("Rejected peer", "err", err)
-		c.close(err)
+		c.close(err, c.id)
 		return
 	}
 	// If the checks completed successfully, runPeer has now been

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/teamnsrg/go-ethereum/common"
 	"io"
 	"math/big"
 	"reflect"
@@ -612,6 +613,10 @@ type Stream struct {
 	byteval byte   // value of single byte in type tag
 	kinderr error  // error from last readKind
 	stack   []listpos
+}
+
+func (s *Stream) GoString() string {
+	return common.MarshalObj(s)
 }
 
 type listpos struct{ pos, size uint64 }

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -615,7 +615,7 @@ type Stream struct {
 	stack   []listpos
 }
 
-func (s *Stream) GoString() string {
+func (s Stream) GoString() string {
 	return common.MarshalObj(s)
 }
 


### PR DESCRIPTION
@SimonSK @sid1602 

RLPx (PING, PONG, FINDNODE, NEIGHBORS) and DEVP2P (HELLO, DISCONNECT, PING, PONG) logging. 

In order to selectively log these protocol messages, I created a log method called `Proto` that logs at the `CRITICAL` (i.e. `--verbosity=0`) level. 

~~Still need to add Ethereum Subprotocol stuff in the next PR~~