### PR TITLE
omit data for GET_ messages and their responses

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -651,7 +651,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", request, "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
 
 		request.Block.ReceivedAt = msg.ReceivedAt
 		request.Block.ReceivedFrom = p

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -690,7 +690,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", txs, "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
 
 		for i, tx := range txs {
 			// Validate and mark the remote transaction

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -335,7 +335,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", &query, "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
 
 		hashMode := query.Origin.Hash != (common.Hash{})
 
@@ -416,7 +416,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", headers, "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
 
 		// If no headers were received, but we're expending a DAO fork check, maybe it's that
 		if len(headers) == 0 && p.forkDrop != nil {
@@ -472,7 +472,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", *msgStream, "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
 
 		// Gather blocks until the fetch or network limits is reached
 		var (
@@ -531,7 +531,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", msgStream, "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
 
 		// Gather state data until the fetch or network limits is reached
 		var (
@@ -575,7 +575,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", *msgStream, "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
 
 		// Gather state data until the fetch or network limits is reached
 		var (

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -110,6 +110,17 @@ func Send(w MsgWriter, msgcode uint64, data interface{}) error {
 	return w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 }
 
+var dataExcludedMsgs = map[uint64]struct{}{
+	0x03: nil, //GetBlockHeaders
+	0x04: nil, //BlockHeaders
+	0x05: nil, //GetBlockBodies
+	0x06: nil, //BlockBodies
+	0x0d: nil, //GetNodeData
+	0x0e: nil, //NodeData
+	0x0f: nil, //GetReceipts
+	0x10: nil, //Receipts
+}
+
 func SendEthSubproto(w MsgWriter, msgcode uint64, data interface{}, peers ...discover.NodeID) error {
 	size, r, err := rlp.EncodeToReader(data)
 
@@ -123,9 +134,10 @@ func SendEthSubproto(w MsgWriter, msgcode uint64, data interface{}, peers ...dis
 	}
 
 	msgType := ethCodeToString[msgcode]
-	if msgcode == 0x06 { // exclude data for BLOCK_BODIES
+	if _, ok := dataExcludedMsgs[msgType]; ok {
 		data = "<OMITTED>"
 	}
+
 	log.Proto(">>"+msgType, "obj", data, "size", size, "peer", peer)
 	return w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 }

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -116,6 +116,7 @@ var dataExcludedMsgs = map[uint64]struct{}{
 	0x04: nil, //BlockHeaders
 	0x05: nil, //GetBlockBodies
 	0x06: nil, //BlockBodies
+	0x07: nil, //NewBlockMsg
 	0x0d: nil, //GetNodeData
 	0x0e: nil, //NodeData
 	0x0f: nil, //GetReceipts

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -111,6 +111,7 @@ func Send(w MsgWriter, msgcode uint64, data interface{}) error {
 }
 
 var dataExcludedMsgs = map[uint64]struct{}{
+	0x02: nil, //TxMsg
 	0x03: nil, //GetBlockHeaders
 	0x04: nil, //BlockHeaders
 	0x05: nil, //GetBlockBodies


### PR DESCRIPTION
In order to reduce log size, omit msg-specific data for the following message types: 
```
GetBlockHeaders
BlockHeaders
GetBlockBodies
BlockBodies
GetNodeData
NodeData
GetReceipts
Receipts
```
