### PR TITLE
log message size in decimal

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -335,7 +335,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
 
 		hashMode := query.Origin.Hash != (common.Hash{})
 
@@ -416,7 +416,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
 
 		// If no headers were received, but we're expending a DAO fork check, maybe it's that
 		if len(headers) == 0 && p.forkDrop != nil {
@@ -472,7 +472,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
 
 		// Gather blocks until the fetch or network limits is reached
 		var (
@@ -502,7 +502,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
 
 		// Deliver them all to the downloader for queuing
 		trasactions := make([][]*types.Transaction, len(request))
@@ -531,7 +531,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
 
 		// Gather state data until the fetch or network limits is reached
 		var (
@@ -561,7 +561,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
 
 		// Deliver all to the downloader
 		if err := pm.downloader.DeliverNodeData(p.id, data); err != nil {
@@ -575,7 +575,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
 
 		// Gather state data until the fetch or network limits is reached
 		var (
@@ -614,7 +614,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
 
 		// Deliver all to the downloader
 		if err := pm.downloader.DeliverReceipts(p.id, receipts); err != nil {
@@ -627,7 +627,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", &announces, "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", &announces, "size", int(msg.Size), "peer", p.ID())
 
 		// Mark the hashes as present at the remote node
 		for _, block := range announces {
@@ -651,7 +651,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
 
 		request.Block.ReceivedAt = msg.ReceivedAt
 		request.Block.ReceivedFrom = p
@@ -690,7 +690,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", msg.Size, "peer", p.ID())
+		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
 
 		for i, tx := range txs {
 			// Validate and mark the remote transaction

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -279,7 +279,7 @@ func (p *peer) readStatus(network uint64, status *statusData, genesis common.Has
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
 
-	p.Log().Proto("<<"+ethCodeToString[msg.Code], "obj", status, "size", msg.Size, "peer", p.ID())
+	p.Log().Proto("<<"+ethCodeToString[msg.Code], "obj", status, "size", int(msg.Size), "peer", p.ID())
 
 	if status.GenesisBlock != genesis {
 		return errResp(ErrGenesisBlockMismatch, "%x (!= %x)", status.GenesisBlock[:8], genesis[:8])

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -141,7 +141,7 @@ func SendEthSubproto(w MsgWriter, msgcode uint64, data interface{}, peers ...dis
 		data = "<OMITTED>"
 	}
 
-	log.Proto(">>"+msgType, "obj", data, "size", size, "peer", peer)
+	log.Proto(">>"+msgType, "obj", data, "size", int(size), "peer", peer)
 	return w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 }
 
@@ -161,7 +161,7 @@ func SendDEVp2p(w MsgWriter, msgcode uint64, data interface{}, peers ...discover
 	if msgcode == discMsg {
 		data = discReasonToString[data.(DiscReason)]
 	}
-	log.Proto(">>"+msgType, "obj", data, "size", uint32(size), "peer", peer)
+	log.Proto(">>"+msgType, "obj", data, "size", int(size), "peer", peer)
 	return w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 }
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -306,18 +306,18 @@ func (p *Peer) handle(msg Msg) error {
 	var emptyMsgObj []interface{}
 	switch {
 	case msg.Code == pingMsg:
-		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", msg.Size, "peer", p.ID())
+		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
 		msg.Discard()
 		go SendDEVp2p(p.rw, pongMsg, make([]interface{}, 0), p.ID())
 	case msg.Code == pongMsg:
-		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", msg.Size, "peer", p.ID())
+		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
 		msg.Discard()
 	case msg.Code == discMsg:
 		var reason [1]DiscReason
 		// This is the last message. We don't need to discard or
 		// check errors because, the connection will be closed after it.
 		rlp.Decode(msg.Payload, &reason)
-		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", discReasonToString[reason[0]], "size", msg.Size, "peer", p.ID())
+		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", discReasonToString[reason[0]], "size", int(msg.Size), "peer", p.ID())
 		return reason[0]
 	case msg.Code < baseProtocolLength:
 		// ignore other base protocol messages

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -155,7 +155,7 @@ func readProtocolHandshake(rw MsgReader, peer discover.NodeID) (*protoHandshake,
 		// back otherwise. Wrap it in a string instead.
 		var reason [1]DiscReason
 		rlp.Decode(msg.Payload, &reason)
-		log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", discReasonToString[reason[0]], "size", msg.Size, "peer", peer)
+		log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", discReasonToString[reason[0]], "size", int(msg.Size), "peer", peer)
 		return nil, reason[0]
 	}
 	if msg.Code != handshakeMsg {
@@ -166,7 +166,7 @@ func readProtocolHandshake(rw MsgReader, peer discover.NodeID) (*protoHandshake,
 		return nil, err
 	}
 
-	log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", &hs, "size", msg.Size, "peer", hs.ID)
+	log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", &hs, "size", int(msg.Size), "peer", hs.ID)
 
 	if (hs.ID == discover.NodeID{}) {
 		return nil, DiscInvalidIdentity


### PR DESCRIPTION
Some message sizes are logged in hex because the size variable is uint32. According to the Go documentation, "uint, uint8 etc.:  %d, %#x if printed with %#v".
I casted it as int so that it is logged in decimal.

