### PR TITLE
log format changes

### DIFF
--- a/log/format.go
+++ b/log/format.go
@@ -105,6 +105,8 @@ func TerminalFormat(usecolor bool) Format {
 
 		b := &bytes.Buffer{}
 		lvl := r.Lvl.AlignedString()
+		unixTime := float64(r.Time.UnixNano())/1000000
+
 		if atomic.LoadUint32(&locationEnabled) != 0 {
 			// Log origin printing was requested, format the location path and line number
 			location := fmt.Sprintf("%+v", r.Call)
@@ -121,15 +123,15 @@ func TerminalFormat(usecolor bool) Format {
 
 			// Assemble and print the log heading
 			if color > 0 {
-				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m [%s|%s] %s", color, lvl, r.Time.Format(termTimeFormat), location, r.Msg)
+				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m %s %f [%s] %s", color, lvl, r.Time.Format(timeFormat), unixTime, location, r.Msg)
 			} else {
-				fmt.Fprintf(b, "%s [%s|%s] %s", lvl, r.Time.Format(termTimeFormat), location, r.Msg)
+				fmt.Fprintf(b, "%s %s %f [%s] %s", lvl, r.Time.Format(timeFormat), unixTime, location, r.Msg)
 			}
 		} else {
 			if color > 0 {
-				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m [%s] %s ", color, lvl, r.Time.Format(termTimeFormat), r.Msg)
+				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m %s %f %s", color, lvl, r.Time.Format(timeFormat), unixTime, r.Msg)
 			} else {
-				fmt.Fprintf(b, "%s [%s] %s ", lvl, r.Time.Format(termTimeFormat), r.Msg)
+				fmt.Fprintf(b, "%s %s %f %s", lvl, r.Time.Format(timeFormat), unixTime, r.Msg)
 			}
 		}
 		// try to justify the log output for short messages

--- a/log/format.go
+++ b/log/format.go
@@ -117,19 +117,19 @@ func TerminalFormat(usecolor bool) Format {
 				align = len(location)
 				atomic.StoreUint32(&locationLength, uint32(align))
 			}
-			padding := strings.Repeat(" ", align-len(location))
+			// padding := strings.Repeat(" ", align-len(location))
 
 			// Assemble and print the log heading
 			if color > 0 {
-				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s|%s]%s %s ", color, lvl, r.Time.Format(termTimeFormat), location, padding, r.Msg)
+				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m [%s|%s] %s", color, lvl, r.Time.Format(termTimeFormat), location, r.Msg)
 			} else {
-				fmt.Fprintf(b, "%s[%s|%s]%s %s ", lvl, r.Time.Format(termTimeFormat), location, padding, r.Msg)
+				fmt.Fprintf(b, "%s [%s|%s] %s", lvl, r.Time.Format(termTimeFormat), location, r.Msg)
 			}
 		} else {
 			if color > 0 {
-				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %s ", color, lvl, r.Time.Format(termTimeFormat), r.Msg)
+				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m [%s] %s ", color, lvl, r.Time.Format(termTimeFormat), r.Msg)
 			} else {
-				fmt.Fprintf(b, "%s[%s] %s ", lvl, r.Time.Format(termTimeFormat), r.Msg)
+				fmt.Fprintf(b, "%s [%s] %s ", lvl, r.Time.Format(termTimeFormat), r.Msg)
 			}
 		}
 		// try to justify the log output for short messages

--- a/log/logger.go
+++ b/log/logger.go
@@ -32,13 +32,13 @@ func (l Lvl) AlignedString() string {
 	case LvlDebug:
 		return "DEBUG"
 	case LvlInfo:
-		return "INFO "
+		return "INFO"
 	case LvlWarn:
-		return "WARN "
+		return "WARN"
 	case LvlError:
 		return "ERROR"
 	case LvlCrit:
-		return "CRIT "
+		return "CRIT"
 	default:
 		panic("bad level")
 	}


### PR DESCRIPTION
changed the log format.
whitespace paddings are removed.
timeformat changed as following:
previously `CRIT [12-20|23:52:11] <<ETH_TX|...`
now `CRIT 2018-01-23T14:33:21-0600 1516739601706.607178 >>FINDNODE/v4|...`