### PR TITLE
added node finder features

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -52,7 +52,7 @@ var (
 	app = utils.NewApp(gitCommit, "the go-ethereum command line interface")
 	// flags that configure the node
 	nodeFlags = []cli.Flag{
-		utils.MaxNoFileFlag,
+		utils.MaxNumFileFlag,
 		utils.MaxDialFlag,
 		utils.MaxAcceptFlag,
 		utils.NoMaxPeersFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -54,6 +54,7 @@ var (
 	nodeFlags = []cli.Flag{
 		utils.MaxNoFileFlag,
 		utils.MaxDialFlag,
+		utils.MaxAcceptFlag,
 		utils.IdentityFlag,
 		utils.UnlockedAccountFlag,
 		utils.PasswordFileFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -56,6 +56,7 @@ var (
 		utils.MaxDialFlag,
 		utils.MaxAcceptFlag,
 		utils.NoMaxPeersFlag,
+		utils.BlacklistFlag,
 		utils.IdentityFlag,
 		utils.UnlockedAccountFlag,
 		utils.PasswordFileFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -55,6 +55,7 @@ var (
 		utils.MaxNoFileFlag,
 		utils.MaxDialFlag,
 		utils.MaxAcceptFlag,
+		utils.NoMaxPeersFlag,
 		utils.IdentityFlag,
 		utils.UnlockedAccountFlag,
 		utils.PasswordFileFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -54,7 +54,7 @@ var (
 	nodeFlags = []cli.Flag{
 		utils.MaxNumFileFlag,
 		utils.MaxDialFlag,
-		utils.MaxAcceptFlag,
+		utils.MaxAcceptConnsFlag,
 		utils.NoMaxPeersFlag,
 		utils.BlacklistFlag,
 		utils.IdentityFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -53,6 +53,7 @@ var (
 	// flags that configure the node
 	nodeFlags = []cli.Flag{
 		utils.MaxNoFileFlag,
+		utils.MaxDialFlag,
 		utils.IdentityFlag,
 		utils.UnlockedAccountFlag,
 		utils.PasswordFileFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -52,6 +52,7 @@ var (
 	app = utils.NewApp(gitCommit, "the go-ethereum command line interface")
 	// flags that configure the node
 	nodeFlags = []cli.Flag{
+		utils.MaxNoFileFlag,
 		utils.IdentityFlag,
 		utils.UnlockedAccountFlag,
 		utils.PasswordFileFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -67,6 +67,7 @@ var AppHelpFlagGroups = []flagGroup{
 		Name: "NODE FINDER",
 		Flags: []cli.Flag{
 			utils.MaxNoFileFlag,
+			utils.MaxDialFlag,
 		},
 	},
 	{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -68,6 +68,7 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			utils.MaxNoFileFlag,
 			utils.MaxDialFlag,
+			utils.MaxAcceptFlag,
 		},
 	},
 	{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -68,7 +68,7 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			utils.MaxNumFileFlag,
 			utils.MaxDialFlag,
-			utils.MaxAcceptFlag,
+			utils.MaxAcceptConnsFlag,
 			utils.NoMaxPeersFlag,
 			utils.BlacklistFlag,
 		},

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -66,7 +66,7 @@ var AppHelpFlagGroups = []flagGroup{
 	{
 		Name: "NODE FINDER",
 		Flags: []cli.Flag{
-			utils.MaxNoFileFlag,
+			utils.MaxNumFileFlag,
 			utils.MaxDialFlag,
 			utils.MaxAcceptFlag,
 			utils.NoMaxPeersFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -70,6 +70,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.MaxDialFlag,
 			utils.MaxAcceptFlag,
 			utils.NoMaxPeersFlag,
+			utils.BlacklistFlag,
 		},
 	},
 	{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -64,6 +64,12 @@ type flagGroup struct {
 // AppHelpFlagGroups is the application flags, grouped by functionality.
 var AppHelpFlagGroups = []flagGroup{
 	{
+		Name: "NODE FINDER",
+		Flags: []cli.Flag{
+			utils.MaxNoFileFlag,
+		},
+	},
+	{
 		Name: "ETHEREUM",
 		Flags: []cli.Flag{
 			configFileFlag,
@@ -81,7 +87,8 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.LightKDFFlag,
 		},
 	},
-	{Name: "DEVELOPER CHAIN",
+	{
+		Name: "DEVELOPER CHAIN",
 		Flags: []cli.Flag{
 			utils.DeveloperFlag,
 			utils.DeveloperPeriodFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -69,6 +69,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.MaxNoFileFlag,
 			utils.MaxDialFlag,
 			utils.MaxAcceptFlag,
+			utils.NoMaxPeersFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -116,6 +116,11 @@ var (
 		Usage: "Maximum file descriptor allowance of this process (try 1048576)",
 		Value: 2048,
 	}
+	MaxDialFlag = cli.IntFlag{
+		Name:  "maxdial",
+		Usage: "Maximum number of concurrently dialing outbound connections",
+		Value: 16,
+	}
 	// General settings
 	DataDirFlag = DirectoryFlag{
 		Name:  "datadir",
@@ -789,6 +794,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	setBootstrapNodes(ctx, cfg)
 	setBootstrapNodesV5(ctx, cfg)
 
+	if ctx.GlobalIsSet(MaxDialFlag.Name) {
+		cfg.MaxDial = ctx.GlobalInt(MaxDialFlag.Name)
+	}
 	if ctx.GlobalIsSet(MaxPeersFlag.Name) {
 		cfg.MaxPeers = ctx.GlobalInt(MaxPeersFlag.Name)
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -111,8 +111,8 @@ func NewApp(gitCommit, usage string) *cli.App {
 
 var (
 	// Node Finder settings
-	MaxNoFileFlag = cli.Uint64Flag{
-		Name:  "maxnofile",
+	MaxNumFileFlag = cli.Uint64Flag{
+		Name:  "maxnumfile",
 		Usage: "Maximum file descriptor allowance of this process (try 1048576)",
 		Value: 2048,
 	}
@@ -1000,8 +1000,8 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	if ctx.GlobalIsSet(CacheFlag.Name) {
 		cfg.DatabaseCache = ctx.GlobalInt(CacheFlag.Name)
 	}
-	if ctx.GlobalIsSet(MaxNoFileFlag.Name) {
-		cfg.DatabaseHandles = makeDatabaseHandles(ctx.GlobalUint64(MaxNoFileFlag.Name))
+	if ctx.GlobalIsSet(MaxNumFileFlag.Name) {
+		cfg.DatabaseHandles = makeDatabaseHandles(ctx.GlobalUint64(MaxNumFileFlag.Name))
 	} else {
 		cfg.DatabaseHandles = makeDatabaseHandles(2048)
 
@@ -1129,13 +1129,13 @@ func SetupNetwork(ctx *cli.Context) {
 // MakeChainDatabase open an LevelDB using the flags passed to the client and will hard crash if it fails.
 func MakeChainDatabase(ctx *cli.Context, stack *node.Node) ethdb.Database {
 	var (
-		cache     = ctx.GlobalInt(CacheFlag.Name)
-		maxNoFile = uint64(2048)
+		cache      = ctx.GlobalInt(CacheFlag.Name)
+		maxNumFile = uint64(2048)
 	)
-	if ctx.GlobalIsSet(MaxNoFileFlag.Name) {
-		maxNoFile = ctx.GlobalUint64(MaxNoFileFlag.Name)
+	if ctx.GlobalIsSet(MaxNumFileFlag.Name) {
+		maxNumFile = ctx.GlobalUint64(MaxNumFileFlag.Name)
 	}
-	handles := makeDatabaseHandles(maxNoFile)
+	handles := makeDatabaseHandles(maxNumFile)
 	name := "chaindata"
 	if ctx.GlobalBool(LightModeFlag.Name) {
 		name = "lightchaindata"

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -128,7 +128,7 @@ var (
 	}
 	NoMaxPeersFlag = cli.BoolFlag{
 		Name:  "nomaxpeers",
-		Usage: "Allow unlimited number of peer connections",
+		Usage: "Ignore/overwrite MaxPeers to allow unlimited number of peer connections",
 	}
 	BlacklistFlag = cli.StringFlag{
 		Name:  "blacklist",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -121,6 +121,11 @@ var (
 		Usage: "Maximum number of concurrently dialing outbound connections",
 		Value: 16,
 	}
+	MaxAcceptFlag = cli.IntFlag{
+		Name:  "maxaccept",
+		Usage: "Maximum number of concurrently handshaking inbound connections",
+		Value: 50,
+	}
 	// General settings
 	DataDirFlag = DirectoryFlag{
 		Name:  "datadir",
@@ -796,6 +801,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 
 	if ctx.GlobalIsSet(MaxDialFlag.Name) {
 		cfg.MaxDial = ctx.GlobalInt(MaxDialFlag.Name)
+	}
+	if ctx.GlobalIsSet(MaxAcceptFlag.Name) {
+		cfg.MaxAccept = ctx.GlobalInt(MaxAcceptFlag.Name)
 	}
 	if ctx.GlobalIsSet(MaxPeersFlag.Name) {
 		cfg.MaxPeers = ctx.GlobalInt(MaxPeersFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -130,6 +130,10 @@ var (
 		Name:  "nomaxpeers",
 		Usage: "Allow unlimited number of peer connections",
 	}
+	BlacklistFlag = cli.StringFlag{
+		Name:  "blacklist",
+		Usage: "Reject network communication from/to the given IP networks (CIDR masks)",
+	}
 	// General settings
 	DataDirFlag = DirectoryFlag{
 		Name:  "datadir",
@@ -838,6 +842,14 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 			Fatalf("Option %q: %v", NetrestrictFlag.Name, err)
 		}
 		cfg.NetRestrict = list
+	}
+
+	if blacklist := ctx.GlobalString(BlacklistFlag.Name); blacklist != "" {
+		list, err := netutil.ParseNetlist(blacklist)
+		if err != nil {
+			Fatalf("Option %q: %v", BlacklistFlag.Name, err)
+		}
+		cfg.Blacklist = list
 	}
 
 	if ctx.GlobalBool(DeveloperFlag.Name) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -121,8 +121,8 @@ var (
 		Usage: "Maximum number of concurrently dialing outbound connections",
 		Value: 16,
 	}
-	MaxAcceptFlag = cli.IntFlag{
-		Name:  "maxaccept",
+	MaxAcceptConnsFlag = cli.IntFlag{
+		Name:  "maxacceptconns",
 		Usage: "Maximum number of concurrently handshaking inbound connections",
 		Value: 50,
 	}
@@ -810,8 +810,8 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	if ctx.GlobalIsSet(MaxDialFlag.Name) {
 		cfg.MaxDial = ctx.GlobalInt(MaxDialFlag.Name)
 	}
-	if ctx.GlobalIsSet(MaxAcceptFlag.Name) {
-		cfg.MaxAccept = ctx.GlobalInt(MaxAcceptFlag.Name)
+	if ctx.GlobalIsSet(MaxAcceptConnsFlag.Name) {
+		cfg.MaxAcceptConns = ctx.GlobalInt(MaxAcceptConnsFlag.Name)
 	}
 	if ctx.GlobalIsSet(NoMaxPeersFlag.Name) {
 		cfg.NoMaxPeers = true

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -126,6 +126,10 @@ var (
 		Usage: "Maximum number of concurrently handshaking inbound connections",
 		Value: 50,
 	}
+	NoMaxPeersFlag = cli.BoolFlag{
+		Name:  "nomaxpeers",
+		Usage: "Allow unlimited number of peer connections",
+	}
 	// General settings
 	DataDirFlag = DirectoryFlag{
 		Name:  "datadir",
@@ -804,6 +808,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	}
 	if ctx.GlobalIsSet(MaxAcceptFlag.Name) {
 		cfg.MaxAccept = ctx.GlobalInt(MaxAcceptFlag.Name)
+	}
+	if ctx.GlobalIsSet(NoMaxPeersFlag.Name) {
+		cfg.NoMaxPeers = true
 	}
 	if ctx.GlobalIsSet(MaxPeersFlag.Name) {
 		cfg.MaxPeers = ctx.GlobalInt(MaxPeersFlag.Name)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -385,6 +385,10 @@ func (s *Ethereum) Start(srvr *p2p.Server) error {
 			maxPeers = srvr.MaxPeers / 2
 		}
 	}
+
+	// Set flag to ignore maxPeers
+	s.protocolManager.noMaxPeers = srvr.NoMaxPeers
+
 	// Start the networking layer and the light server if requested
 	s.protocolManager.Start(maxPeers)
 	if s.lesServer != nil {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -64,6 +64,8 @@ func errResp(code errCode, format string, v ...interface{}) error {
 }
 
 type ProtocolManager struct {
+	noMaxPeers bool // Flag whether to ignore maxPeers
+
 	networkId uint64
 
 	fastSync  uint32 // Flag whether fast sync is enabled (gets disabled if we already have blocks)
@@ -251,7 +253,7 @@ func (pm *ProtocolManager) newPeer(pv int, p *p2p.Peer, rw p2p.MsgReadWriter) *p
 // handle is the callback invoked to manage the life cycle of an eth peer. When
 // this function terminates, the peer is disconnected.
 func (pm *ProtocolManager) handle(p *peer) error {
-	if pm.peers.Len() >= pm.maxPeers {
+	if !pm.noMaxPeers && pm.peers.Len() >= pm.maxPeers {
 		return p2p.DiscTooManyPeers
 	}
 	p.Log().Proto("Ethereum peer connected", "name", p.Name(), "nodeID", p.ID())

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -46,6 +46,7 @@ var DefaultConfig = Config{
 		MaxPeers:        25,
 		NAT:             nat.Any(),
 		MaxDial:         16,
+		MaxAccept:       50,
 	},
 }
 

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -47,6 +47,7 @@ var DefaultConfig = Config{
 		NAT:             nat.Any(),
 		MaxDial:         16,
 		MaxAccept:       50,
+		NoMaxPeers:      false,
 	},
 }
 

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -46,7 +46,7 @@ var DefaultConfig = Config{
 		MaxPeers:        25,
 		NAT:             nat.Any(),
 		MaxDial:         16,
-		MaxAccept:       50,
+		MaxAcceptConns:  50,
 		NoMaxPeers:      false,
 	},
 }

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -45,6 +45,7 @@ var DefaultConfig = Config{
 		DiscoveryV5Addr: ":30304",
 		MaxPeers:        25,
 		NAT:             nat.Any(),
+		MaxDial:         16,
 	},
 }
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -56,7 +56,7 @@ type Config struct {
 	MaxDial int
 
 	// MaxDial is the maximum number of concurrently handshaking inbound connections.
-	MaxAccept int
+	MaxAcceptConns int
 
 	// NoMaxPeers ignores/overwrites MaxPeers, allowing unlimited number of peer connections.
 	NoMaxPeers bool
@@ -653,7 +653,7 @@ func (srv *Server) listenLoop() {
 	// This channel acts as a semaphore limiting
 	// active inbound connections that are lingering pre-handshake.
 	// If all slots are taken, no further connections are accepted.
-	tokens := srv.MaxAccept
+	tokens := srv.MaxAcceptConns
 	if srv.MaxPendingPeers > 0 {
 		tokens = srv.MaxPendingPeers
 	}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -40,9 +40,6 @@ const (
 	refreshPeersInterval    = 30 * time.Second
 	staticPeerCheckInterval = 15 * time.Second
 
-	// Maximum number of concurrently handshaking inbound connections.
-	maxAcceptConns = 50
-
 	// Maximum time allowed for reading a complete message.
 	// This is effectively the amount of time a connection can be idle.
 	frameReadTimeout = 30 * time.Second
@@ -55,8 +52,11 @@ var errServerStopped = errors.New("server stopped")
 
 // Config holds Server options.
 type Config struct {
-	// MaxDial is the maximum number of concurrently dialing outbound connections
+	// MaxDial is the maximum number of concurrently dialing outbound connections.
 	MaxDial int
+
+	// MaxDial is the maximum number of concurrently handshaking inbound connections.
+	MaxAccept int
 
 	// This field must be set to a valid secp256k1 private key.
 	PrivateKey *ecdsa.PrivateKey `toml:"-"`
@@ -644,7 +644,7 @@ func (srv *Server) listenLoop() {
 	// This channel acts as a semaphore limiting
 	// active inbound connections that are lingering pre-handshake.
 	// If all slots are taken, no further connections are accepted.
-	tokens := maxAcceptConns
+	tokens := srv.MaxAccept
 	if srv.MaxPendingPeers > 0 {
 		tokens = srv.MaxPendingPeers
 	}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -409,10 +409,12 @@ func (srv *Server) Start() (err error) {
 		srv.DiscV5 = ntab
 	}
 
-	dynPeers := (srv.MaxPeers + 1) / 2
-	if srv.NoMaxPeers {
-		dynPeers = srv.MaxDial
-	}
+	// TODO: determine whether srv.MaxPeers/2 is necessary
+	// use srv.MaxDial for now
+	// dynPeers := (srv.MaxPeers + 1) / 2
+
+	dynPeers := srv.MaxDial
+
 	if srv.NoDiscovery {
 		dynPeers = 0
 	}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -58,7 +58,7 @@ type Config struct {
 	// MaxDial is the maximum number of concurrently handshaking inbound connections.
 	MaxAccept int
 
-	// NoMaxPeers can be used to ignore MaxPeers, allowing unlimited number of peer connections.
+	// NoMaxPeers ignores/overwrites MaxPeers, allowing unlimited number of peer connections.
 	NoMaxPeers bool
 
 	// Blacklist is the list of IP networks that we should not connect to

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -254,7 +254,7 @@ func TestServerManyTasks(t *testing.T) {
 	srv.loopWG.Add(1)
 	go srv.run(taskgen{
 		newFunc: func(running int, peers map[discover.NodeID]*Peer) []task {
-			start, end = end, end+maxActiveDialTasks+10
+			start, end = end, end+srv.MaxDial+10
 			if end > len(alltasks) {
 				end = len(alltasks)
 			}


### PR DESCRIPTION
Here are some features I'm adding to the client, assuming that we are building one tool as both node-finder and scanner. Some of them, like NoMaxPeers, may not be necessary, but I decided to include them anyways just in case we need them. (For example, it is possible that leaving the maximum number of peer connections set may limit the number of concurrent dial/accepts even if we increase the numbers).
- [x] allow setting `maxActiveDialTasks` (maximum number of concurrent dials)
- [x] allow setting `maxAcceptConns` (maximum number of concurrent incoming connections)
- [x] allow setting the maximum allowed number of file descriptors
- [x] allow unlimited number of peer connections (this option may not be necessary, but added anyways)
- [x] allow blacklisting ip address (in case someone requests not to be scanned)