### PR TITLE
lock for concurrent read/write hashmap

### DIFF
--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -198,7 +198,9 @@ func (srv *Server) getNodeAddress(c *conn, receivedAt *time.Time) (*Info, bool, 
 	if p, err := strconv.ParseUint(addrArr[addrLen-1], 10, 16); err == nil {
 		remotePort = uint16(p)
 	}
+	srv.KnownNodeInfos.RLock()
 	oldNodeInfo := srv.KnownNodeInfos.Infos()[c.id]
+	srv.KnownNodeInfos.RUnlock()
 
 	var hash string
 	if oldNodeInfo != nil {


### PR DESCRIPTION
Fix for concurrent map read/write
Error message:
```
fatal error: concurrent map read and map write

goroutine 2528542 [running]:
runtime.throw(0xff1610, 0x21)
        /usr/lib/go-1.8/src/runtime/panic.go:596 +0x95 fp=0xc42576f750 sp=0xc42576f730
runtime.mapaccess1(0xe65940, 0xc42029e9c0, 0xc42454e850, 0x10)
        /usr/lib/go-1.8/src/runtime/hashmap.go:319 +0x23a fp=0xc42576f798 sp=0xc42576f750
github.com/teamnsrg/go-ethereum/p2p.(*Server).getNodeAddress(0xc420285080, 0xc42454e820, 0xc427cea8a0, 0xde1500, 0xc4254e6090)
        /home/simon/go/src/github.com/teamnsrg/go-ethereum/build/_workspace/src/github.com/teamnsrg/go-ethereum/p2p/node_info.go:223 +0x193 fp=0xc42576f888 sp=0xc42576f798
github.com/teamnsrg/go-ethereum/p2p.(*Server).storeNodeInfo(0xc420285080, 0xc42454e820, 0xc427cea8a0, 0xc4254e6090)
        /home/simon/go/src/github.com/teamnsrg/go-ethereum/build/_workspace/src/github.com/teamnsrg/go-ethereum/p2p/node_info.go:265 +0x7f fp=0xc42576fbc0 sp=0xc42576f888
github.com/teamnsrg/go-ethereum/p2p.(*Server).SetupConn(0xc420285080, 0x1861860, 0xc4205d3668, 0x4, 0x0)
        /home/simon/go/src/github.com/teamnsrg/go-ethereum/build/_workspace/src/github.com/teamnsrg/go-ethereum/p2p/server.go:841 +0xe82 fp=0xc42576ff88 sp=0xc42576fbc0
github.com/teamnsrg/go-ethereum/p2p.(*Server).listenLoop.func1(0xc420285080, 0x1861860, 0xc4205d3668, 0xc420086480)
        /home/simon/go/src/github.com/teamnsrg/go-ethereum/build/_workspace/src/github.com/teamnsrg/go-ethereum/p2p/server.go:779 +0x51 fp=0xc42576ffc0 sp=0xc42576ff88
runtime.goexit()
        /usr/lib/go-1.8/src/runtime/asm_amd64.s:2197 +0x1 fp=0xc42576ffc8 sp=0xc42576ffc0
created by github.com/teamnsrg/go-ethereum/p2p.(*Server).listenLoop
        /home/simon/go/src/github.com/teamnsrg/go-ethereum/build/_workspace/src/github.com/teamnsrg/go-ethereum/p2p/server.go:781 +0x552
```