### PR TITLE
new dial logic

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -460,7 +460,7 @@ func (srv *Server) Start() (err error) {
 	if srv.NoDiscovery {
 		dynPeers = 0
 	}
-	dialer := newDialState(srv.StaticNodes, srv.BootstrapNodes, srv.ntab, dynPeers, srv.NetRestrict)
+	dialer := newDialState(srv.StaticNodes, srv.ntab, dynPeers, srv.NetRestrict)
 	dialer.setBlacklist(srv.Blacklist)
 	dialer.setDialFreq(srv.DialFreq)
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -385,6 +385,9 @@ func (srv *Server) Start() (err error) {
 		return errors.New("server already running")
 	}
 
+	// add bootnodes to static
+	srv.StaticNodes = append(srv.StaticNodes, srv.BootstrapNodes...)
+
 	srv.KnownNodeInfos = &knownNodeInfos{infos: make(map[discover.NodeID]*Info)}
 
 	// initiate sql connection and prepare statements

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -84,6 +84,26 @@ func startTestServer(t *testing.T, id discover.NodeID, pf func(*Peer)) *Server {
 	return server
 }
 
+func startTestConnectServer(listener net.Listener, t *testing.T, id discover.NodeID, pf func(*Peer)) *Server {
+	tcpAddr := listener.Addr().(*net.TCPAddr)
+	config := Config{
+		Name:        "test",
+		MaxPeers:    10,
+		ListenAddr:  "127.0.0.1:0",
+		PrivateKey:  newkey(),
+		StaticNodes: []*discover.Node{&discover.Node{ID: id, IP: tcpAddr.IP, TCP: uint16(tcpAddr.Port)}},
+	}
+	server := &Server{
+		Config:       config,
+		newPeerHook:  pf,
+		newTransport: func(fd net.Conn) transport { return newTestTransport(id, fd) },
+	}
+	if err := server.Start(); err != nil {
+		t.Fatalf("Could not start server: %v", err)
+	}
+	return server
+}
+
 func TestServerListen(t *testing.T) {
 	// start the test server
 	connected := make(chan *Peer)
@@ -144,15 +164,11 @@ func TestServerDial(t *testing.T) {
 	// start the server
 	connected := make(chan *Peer)
 	remid := randomID()
-	srv := startTestServer(t, remid, func(p *Peer) { connected <- p })
+	srv := startTestConnectServer(listener, t, remid, func(p *Peer) { connected <- p })
 	srv.MaxDial = 16
 	srv.MaxAcceptConns = 50
 	defer close(connected)
 	defer srv.Stop()
-
-	// tell the server to connect
-	tcpAddr := listener.Addr().(*net.TCPAddr)
-	srv.AddPeer(&discover.Node{ID: remid, IP: tcpAddr.IP, TCP: uint16(tcpAddr.Port)})
 
 	select {
 	case conn := <-accepted:
@@ -303,6 +319,9 @@ type taskgen struct {
 
 func (tg taskgen) newTasks(running int, peers map[discover.NodeID]*Peer, now time.Time) []task {
 	return tg.newFunc(running, peers)
+}
+func (tg taskgen) newRedialTasks(peers map[discover.NodeID]*Peer, now time.Time) []task {
+	return nil
 }
 func (tg taskgen) taskDone(t task, now time.Time) {
 	tg.doneFunc(t)

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -91,7 +91,7 @@ func startTestConnectServer(listener net.Listener, t *testing.T, id discover.Nod
 		MaxPeers:    10,
 		ListenAddr:  "127.0.0.1:0",
 		PrivateKey:  newkey(),
-		StaticNodes: []*discover.Node{&discover.Node{ID: id, IP: tcpAddr.IP, TCP: uint16(tcpAddr.Port)}},
+		StaticNodes: []*discover.Node{{ID: id, IP: tcpAddr.IP, TCP: uint16(tcpAddr.Port)}},
 	}
 	server := &Server{
 		Config:       config,


### PR DESCRIPTION
Geth normally schedules `discoverTask` and both static and dynamic `dialTask`s through one function `newTasks`. To enable more consistent redials, redial (static dial) tasks are now handled separately from other tasks.
A few other changes are made to the dial logic as well.
Changes:
- Static dial tasks are handled independently
- Bootnodes are added to static node list so that node-finder periodically monitors their status as well.
- Tasks involving bootnodes are removed from the dial logic. They are being periodically redialed anyways.