### PR TITLE
eth-monitor options 2

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -208,7 +208,7 @@ func init() {
 					log.LvlMatchFilterFileHandler(log.LvlDiscPeer, datadir),
 					log.LvlMatchFilterFileHandler(log.LvlStatus, datadir),
 					log.LvlMatchFilterFileHandler(log.LvlDaoFork, datadir),
-					//log.LvlMatchFilterFileHandler(log.LvlTxData, datadir),
+					log.LvlMatchFilterFileHandler(log.LvlTxData, datadir),
 					log.LvlMatchFilterFileHandler(log.LvlTxRx, datadir),
 					//log.LvlMatchFilterFileHandler(log.LvlTxTx, datadir),
 					log.LvlMatchFilterFileHandler(log.LvlNewBlockRx, datadir),

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -193,17 +193,38 @@ func init() {
 		var glogger *log.GlogHandler
 		datadir := ctx.GlobalString(utils.DataDirFlag.Name)
 		if !isCommand && ctx.GlobalBool(utils.LogToFileFlag.Name) {
-			glogger = log.NewGlogHandler(log.Must.FileHandler(datadir+"/eth-monitor.log", log.TerminalFormat(false)))
-		}
-		if gl, err := debug.Setup(glogger, ctx); err != nil {
-			return err
+			newgl := log.NewGlogHandler(log.Must.FileHandler(datadir+"/eth-monitor.log", log.TerminalFormat(false)))
+			if gl, err := debug.Setup(newgl, ctx); err != nil {
+				return err
+			} else {
+				glogger = gl
+				log.Root().SetHandler(log.MultiHandler(
+					// default logging for any lvl <= verbosity
+					glogger,
+					// lvl specific logging
+					log.LvlMatchFilterFileHandler(log.LvlNeighbors, datadir),
+					log.LvlMatchFilterFileHandler(log.LvlHello, datadir),
+					log.LvlMatchFilterFileHandler(log.LvlDiscProto, datadir),
+					log.LvlMatchFilterFileHandler(log.LvlDiscPeer, datadir),
+					log.LvlMatchFilterFileHandler(log.LvlStatus, datadir),
+					log.LvlMatchFilterFileHandler(log.LvlDaoFork, datadir),
+					log.LvlMatchFilterFileHandler(log.LvlTxRx, datadir),
+					//log.LvlMatchFilterFileHandler(log.LvlTxTx, datadir),
+					log.LvlMatchFilterFileHandler(log.LvlNewBlockRx, datadir),
+					//log.LvlMatchFilterFileHandler(log.LvlNewBlockTx, datadir),
+					log.LvlMatchFilterFileHandler(log.LvlNewBlockHashesRx, datadir),
+					//log.LvlMatchFilterFileHandler(log.LvlNewBlockHashesTx, datadir),
+				))
+			}
 		} else {
-			log.Root().SetHandler(log.MultiHandler(
-				// default logging for any lvl <= verbosity
-				gl,
-			))
-			log.Root().SetGlogger(gl)
+			if gl, err := debug.Setup(nil, ctx); err != nil {
+				return err
+			} else {
+				glogger = gl
+				log.Root().SetHandler(gl)
+			}
 		}
+		log.Root().SetGlogger(glogger)
 		// Start system runtime metrics collection
 		go metrics.CollectProcessMetrics(3 * time.Second)
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -208,6 +208,7 @@ func init() {
 					log.LvlMatchFilterFileHandler(log.LvlDiscPeer, datadir),
 					log.LvlMatchFilterFileHandler(log.LvlStatus, datadir),
 					log.LvlMatchFilterFileHandler(log.LvlDaoFork, datadir),
+					//log.LvlMatchFilterFileHandler(log.LvlTxData, datadir),
 					log.LvlMatchFilterFileHandler(log.LvlTxRx, datadir),
 					//log.LvlMatchFilterFileHandler(log.LvlTxTx, datadir),
 					log.LvlMatchFilterFileHandler(log.LvlNewBlockRx, datadir),

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -211,6 +211,7 @@ func init() {
 					log.LvlMatchFilterFileHandler(log.LvlTxData, datadir),
 					log.LvlMatchFilterFileHandler(log.LvlTxRx, datadir),
 					//log.LvlMatchFilterFileHandler(log.LvlTxTx, datadir),
+					log.LvlMatchFilterFileHandler(log.LvlNewBlockData, datadir),
 					log.LvlMatchFilterFileHandler(log.LvlNewBlockRx, datadir),
 					//log.LvlMatchFilterFileHandler(log.LvlNewBlockTx, datadir),
 					log.LvlMatchFilterFileHandler(log.LvlNewBlockHashesRx, datadir),

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -399,6 +399,18 @@ Uncles:
 	return str
 }
 
+func (b *Block) LogString() string {
+	enc, _ := rlp.EncodeToBytes(extblock{
+		Header: b.header,
+		Txs:    b.transactions,
+		Uncles: b.uncles,
+	})
+	return fmt.Sprintf("Hash:%x Number:%s Timestamp:%s "+
+		"ParentHash:%x Sha3Uncles:%x Miner:%x Size:%d ExtraData:%x Encoded:%x",
+		b.Hash(), b.Number().String(), b.Time().String(), b.ParentHash(), b.UncleHash(), b.Coinbase(),
+		b.Size().Int64(), b.Extra(), enc)
+}
+
 func (h *Header) String() string {
 	return fmt.Sprintf(`Header(%x):
 [

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -336,9 +336,9 @@ func (tx *Transaction) LogString() string {
 		to = fmt.Sprintf("%x", tx.data.Recipient[:])
 	}
 	enc, _ := rlp.EncodeToBytes(&tx.data)
-	return fmt.Sprintf("Hash:%x Contract:%v From:%s To:%s Nonce:%v GasPrice:%s GasLimit:%s Value:%s Data:0x%x "+
+	return fmt.Sprintf("Hash:%x Contract:%v From:%s To:%s Nonce:%v GasPrice:%s GasLimit:%s Value:%s Data:%x "+
 		"V:%s R:%s S:%s Encoded:%x",
-		tx.Hash().String()[2:], tx.data.Recipient == nil, from, to, tx.data.AccountNonce,
+		tx.Hash(), tx.data.Recipient == nil, from, to, tx.data.AccountNonce,
 		tx.data.Price.String(), tx.data.GasLimit.String(), tx.data.Amount.String(), tx.data.Payload,
 		tx.data.V.String(), tx.data.R.String(), tx.data.S.String(), enc)
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -315,6 +315,34 @@ func (tx *Transaction) String() string {
 	)
 }
 
+func (tx *Transaction) LogString() string {
+	var from, to string
+	if tx.data.V != nil {
+		// make a best guess about the signer and use that to derive
+		// the sender.
+		signer := deriveSigner(tx.data.V)
+		if f, err := Sender(signer, tx); err != nil { // derive but don't cache
+			from = "[invalid-sig]"
+		} else {
+			from = fmt.Sprintf("%x", f[:])
+		}
+	} else {
+		from = "[nil-V]"
+	}
+
+	if tx.data.Recipient == nil {
+		to = "[contract-creation]"
+	} else {
+		to = fmt.Sprintf("%x", tx.data.Recipient[:])
+	}
+	enc, _ := rlp.EncodeToBytes(&tx.data)
+	return fmt.Sprintf("Hash:%x Contract:%v From:%s To:%s Nonce:%v GasPrice:%s GasLimit:%s Value:%s Data:0x%x "+
+		"V:%s R:%s S:%s Encoded:%x",
+		tx.Hash().String()[2:], tx.data.Recipient == nil, from, to, tx.data.AccountNonce,
+		tx.data.Price.String(), tx.data.GasLimit.String(), tx.data.Amount.String(), tx.data.Payload,
+		tx.data.V.String(), tx.data.R.String(), tx.data.S.String(), enc)
+}
+
 // Transaction slice type for basic sorting.
 type Transactions []*Transaction
 

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -80,6 +80,13 @@ func newPeer(version int, p *p2p.Peer, rw p2p.MsgReadWriter) *peer {
 	}
 }
 
+func (p *peer) suppressMessageError(err error) error {
+	if err != nil {
+		p.Log().Debug("Ethereum message handling failed", "err", err)
+	}
+	return nil
+}
+
 // Info gathers and returns a collection of metadata known about a peer.
 func (p *peer) Info() *PeerInfo {
 	hash, td := p.Head()

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -17,13 +17,10 @@
 package eth
 
 import (
-	"fmt"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/teamnsrg/go-ethereum/common"
-	"github.com/teamnsrg/go-ethereum/core/types"
 	"github.com/teamnsrg/go-ethereum/crypto"
 	"github.com/teamnsrg/go-ethereum/eth/downloader"
 	"github.com/teamnsrg/go-ethereum/p2p"
@@ -86,92 +83,6 @@ func testStatusMsgErrors(t *testing.T, protocol int) {
 		}
 		p.close()
 	}
-}
-
-// This test checks that received transactions are added to the local pool.
-func TestRecvTransactions62(t *testing.T) { testRecvTransactions(t, 62) }
-func TestRecvTransactions63(t *testing.T) { testRecvTransactions(t, 63) }
-
-func testRecvTransactions(t *testing.T, protocol int) {
-	txAdded := make(chan []*types.Transaction)
-	pm := newTestProtocolManagerMust(t, downloader.FullSync, 0, nil, txAdded)
-	pm.acceptTxs = 1 // mark synced to accept transactions
-	p, _ := newTestPeer("peer", protocol, pm, true)
-	defer pm.Stop()
-	defer p.close()
-
-	tx := newTestTransaction(testAccount, 0, 0)
-	if err := p2p.Send(p.app, TxMsg, []interface{}{tx}); err != nil {
-		t.Fatalf("send error: %v", err)
-	}
-	select {
-	case added := <-txAdded:
-		if len(added) != 1 {
-			t.Errorf("wrong number of added transactions: got %d, want 1", len(added))
-		} else if added[0].Hash() != tx.Hash() {
-			t.Errorf("added wrong tx hash: got %v, want %v", added[0].Hash(), tx.Hash())
-		}
-	case <-time.After(2 * time.Second):
-		t.Errorf("no TxPreEvent received within 2 seconds")
-	}
-}
-
-// This test checks that pending transactions are sent.
-func TestSendTransactions62(t *testing.T) { testSendTransactions(t, 62) }
-func TestSendTransactions63(t *testing.T) { testSendTransactions(t, 63) }
-
-func testSendTransactions(t *testing.T, protocol int) {
-	pm := newTestProtocolManagerMust(t, downloader.FullSync, 0, nil, nil)
-	defer pm.Stop()
-
-	// Fill the pool with big transactions.
-	const txsize = txsyncPackSize / 10
-	alltxs := make([]*types.Transaction, 100)
-	for nonce := range alltxs {
-		alltxs[nonce] = newTestTransaction(testAccount, uint64(nonce), txsize)
-	}
-	pm.txpool.AddRemotes(alltxs)
-
-	// Connect several peers. They should all receive the pending transactions.
-	var wg sync.WaitGroup
-	checktxs := func(p *testPeer) {
-		defer wg.Done()
-		defer p.close()
-		seen := make(map[common.Hash]bool)
-		for _, tx := range alltxs {
-			seen[tx.Hash()] = false
-		}
-		for n := 0; n < len(alltxs) && !t.Failed(); {
-			var txs []*types.Transaction
-			msg, err := p.app.ReadMsg()
-			if err != nil {
-				t.Errorf("%v: read error: %v", p.Peer, err)
-			} else if msg.Code != TxMsg {
-				t.Errorf("%v: got code %d, want TxMsg", p.Peer, msg.Code)
-			}
-			if err := msg.Decode(&txs); err != nil {
-				t.Errorf("%v: %v", p.Peer, err)
-			}
-			for _, tx := range txs {
-				hash := tx.Hash()
-				seentx, want := seen[hash]
-				if seentx {
-					t.Errorf("%v: got tx more than once: %x", p.Peer, hash)
-				}
-				if !want {
-					t.Errorf("%v: got unexpected tx: %x", p.Peer, hash)
-				}
-				seen[hash] = true
-				n++
-			}
-		}
-	}
-	for i := 0; i < 3; i++ {
-		p, _ := newTestPeer(fmt.Sprintf("peer #%d", i), protocol, pm, true)
-		wg.Add(1)
-		go checktxs(p)
-	}
-	wg.Wait()
 }
 
 // Tests that the custom union field encoder and decoder works correctly.

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -17,15 +17,12 @@
 package eth
 
 import (
-	"math/rand"
 	"sync/atomic"
 	"time"
 
-	"github.com/teamnsrg/go-ethereum/common"
 	"github.com/teamnsrg/go-ethereum/core/types"
 	"github.com/teamnsrg/go-ethereum/eth/downloader"
 	"github.com/teamnsrg/go-ethereum/log"
-	"github.com/teamnsrg/go-ethereum/p2p/discover"
 )
 
 const (
@@ -40,93 +37,6 @@ const (
 type txsync struct {
 	p   *peer
 	txs []*types.Transaction
-}
-
-// syncTransactions starts sending all currently pending transactions to the given peer.
-func (pm *ProtocolManager) syncTransactions(p *peer) {
-	var txs types.Transactions
-	pending, _ := pm.txpool.Pending()
-	for _, batch := range pending {
-		txs = append(txs, batch...)
-	}
-	if len(txs) == 0 {
-		return
-	}
-	select {
-	case pm.txsyncCh <- &txsync{p, txs}:
-	case <-pm.quitSync:
-	}
-}
-
-// txsyncLoop takes care of the initial transaction sync for each new
-// connection. When a new peer appears, we relay all currently pending
-// transactions. In order to minimise egress bandwidth usage, we send
-// the transactions in small packs to one peer at a time.
-func (pm *ProtocolManager) txsyncLoop() {
-	var (
-		pending = make(map[discover.NodeID]*txsync)
-		sending = false               // whether a send is active
-		pack    = new(txsync)         // the pack that is being sent
-		done    = make(chan error, 1) // result of the send
-	)
-
-	// send starts a sending a pack of transactions from the sync.
-	send := func(s *txsync) {
-		// Fill pack with transactions up to the target size.
-		size := common.StorageSize(0)
-		pack.p = s.p
-		pack.txs = pack.txs[:0]
-		for i := 0; i < len(s.txs) && size < txsyncPackSize; i++ {
-			pack.txs = append(pack.txs, s.txs[i])
-			size += s.txs[i].Size()
-		}
-		// Remove the transactions that will be sent.
-		s.txs = s.txs[:copy(s.txs, s.txs[len(pack.txs):])]
-		if len(s.txs) == 0 {
-			delete(pending, s.p.ID())
-		}
-		// Send the pack in the background.
-		s.p.Log().Trace("Sending batch of transactions", "count", len(pack.txs), "bytes", size)
-		sending = true
-		go func() { done <- pack.p.SendTransactions(pack.txs) }()
-	}
-
-	// pick chooses the next pending sync.
-	pick := func() *txsync {
-		if len(pending) == 0 {
-			return nil
-		}
-		n := rand.Intn(len(pending)) + 1
-		for _, s := range pending {
-			if n--; n == 0 {
-				return s
-			}
-		}
-		return nil
-	}
-
-	for {
-		select {
-		case s := <-pm.txsyncCh:
-			pending[s.p.ID()] = s
-			if !sending {
-				send(s)
-			}
-		case err := <-done:
-			sending = false
-			// Stop tracking peers that cause send failures.
-			if err != nil {
-				pack.p.Log().Debug("Transaction send failed", "err", err)
-				delete(pending, pack.p.ID())
-			}
-			// Schedule the next send.
-			if s := pick(); s != nil {
-				send(s)
-			}
-		case <-pm.quitSync:
-			return
-		}
-	}
 }
 
 // syncer is responsible for periodically synchronising with the network, both

--- a/log/format.go
+++ b/log/format.go
@@ -82,6 +82,8 @@ func TerminalFormat(usecolor bool) Format {
 				color = 36
 			case LvlTrace:
 				color = 34
+			default:
+				color = 37
 			}
 		}
 

--- a/log/handler.go
+++ b/log/handler.go
@@ -193,17 +193,17 @@ func LvlFilterHandler(maxLvl Lvl, h Handler) Handler {
 	}, h)
 }
 
-// LvlMatchFilterHandler returns a Handler that only writes
+// LvlMatchFilterFileHandler returns a Handler that only writes
 // records which are equal to the given verbosity
-// level to the wrapped Handler. For example, to only
-// log Error records:
+// level to a FileHandler. For example, to only
+// log Error records to datadir/eror.log:
 //
-//     log.LvlMatchFilterHandler(log.LvlError, log.StdoutHandler)
+//     log.LvlMatchFilterFileHandler(log.LvlError, datadir)
 //
-func LvlMatchFilterHandler(maxLvl Lvl, h Handler) Handler {
+func LvlMatchFilterFileHandler(targetLvl Lvl, logDir string) Handler {
 	return FilterHandler(func(r *Record) (pass bool) {
-		return r.Lvl == maxLvl
-	}, h)
+		return r.Lvl == targetLvl
+	}, Must.FileHandler(fmt.Sprintf("%s/%s.log", logDir, targetLvl.String()), TerminalFormat(false)))
 }
 
 // A MultiHandler dispatches any write to each of its handlers.

--- a/log/logger.go
+++ b/log/logger.go
@@ -28,6 +28,7 @@ const (
 	LvlDiscPeer
 	LvlStatus
 	LvlDaoFork
+	LvlTxData
 	LvlTxRx
 	LvlTxTx
 	LvlNewBlockRx
@@ -63,6 +64,8 @@ func (l Lvl) AlignedString() string {
 		return "STATUS"
 	case LvlDaoFork:
 		return "DAOFORK"
+	case LvlTxData:
+		return "TXDATA"
 	case LvlTxRx:
 		return "TXRX"
 	case LvlTxTx:
@@ -107,6 +110,8 @@ func (l Lvl) String() string {
 		return "status"
 	case LvlDaoFork:
 		return "daofork"
+	case LvlTxData:
+		return "tx-data"
 	case LvlTxRx:
 		return "tx-rx"
 	case LvlTxTx:
@@ -152,6 +157,8 @@ func LvlFromString(lvlString string) (Lvl, error) {
 		return LvlStatus, nil
 	case "daofork":
 		return LvlDaoFork, nil
+	case "tx-data":
+		return LvlTxData, nil
 	case "tx-rx":
 		return LvlTxRx, nil
 	case "tx-tx":
@@ -213,6 +220,7 @@ type Logger interface {
 	DiscPeer(msg string, ctx ...interface{})
 	Status(msg string, ctx ...interface{})
 	DaoFork(msg string, ctx ...interface{})
+	TxData(msg string, ctx ...interface{})
 	TxRx(msg string, ctx ...interface{})
 	TxTx(msg string, ctx ...interface{})
 	NewBlockRx(msg string, ctx ...interface{})
@@ -304,6 +312,10 @@ func (l *logger) Status(msg string, ctx ...interface{}) {
 
 func (l *logger) DaoFork(msg string, ctx ...interface{}) {
 	l.write(msg, LvlDaoFork, ctx)
+}
+
+func (l *logger) TxData(msg string, ctx ...interface{}) {
+	l.write(msg, LvlTxData, ctx)
 }
 
 func (l *logger) TxRx(msg string, ctx ...interface{}) {

--- a/log/logger.go
+++ b/log/logger.go
@@ -22,6 +22,18 @@ const (
 	LvlInfo
 	LvlDebug
 	LvlTrace
+	LvlNeighbors
+	LvlHello
+	LvlDiscProto
+	LvlDiscPeer
+	LvlStatus
+	LvlDaoFork
+	LvlTxRx
+	LvlTxTx
+	LvlNewBlockRx
+	LvlNewBlockTx
+	LvlNewBlockHashesRx
+	LvlNewBlockHashesTx
 )
 
 // Aligned returns a 5-character string containing the name of a Lvl.
@@ -39,6 +51,30 @@ func (l Lvl) AlignedString() string {
 		return "ERROR"
 	case LvlCrit:
 		return "CRIT"
+	case LvlNeighbors:
+		return "NEIGHBORS"
+	case LvlHello:
+		return "HELLO"
+	case LvlDiscProto:
+		return "DISCPROTO"
+	case LvlDiscPeer:
+		return "DISCPEER"
+	case LvlStatus:
+		return "STATUS"
+	case LvlDaoFork:
+		return "DAOFORK"
+	case LvlTxRx:
+		return "TXRX"
+	case LvlTxTx:
+		return "TXTX"
+	case LvlNewBlockRx:
+		return "NBRX"
+	case LvlNewBlockTx:
+		return "NBTX"
+	case LvlNewBlockHashesRx:
+		return "NHRX"
+	case LvlNewBlockHashesTx:
+		return "NHTX"
 	default:
 		panic("bad level")
 	}
@@ -59,6 +95,30 @@ func (l Lvl) String() string {
 		return "eror"
 	case LvlCrit:
 		return "crit"
+	case LvlNeighbors:
+		return "neighbors"
+	case LvlHello:
+		return "hello"
+	case LvlDiscProto:
+		return "disc-proto"
+	case LvlDiscPeer:
+		return "disc-peer"
+	case LvlStatus:
+		return "status"
+	case LvlDaoFork:
+		return "daofork"
+	case LvlTxRx:
+		return "tx-rx"
+	case LvlTxTx:
+		return "tx-tx"
+	case LvlNewBlockRx:
+		return "newblock-rx"
+	case LvlNewBlockTx:
+		return "newblock-tx"
+	case LvlNewBlockHashesRx:
+		return "newblockhashes-rx"
+	case LvlNewBlockHashesTx:
+		return "newblockhashes-tx"
 	default:
 		panic("bad level")
 	}
@@ -80,6 +140,30 @@ func LvlFromString(lvlString string) (Lvl, error) {
 		return LvlError, nil
 	case "crit":
 		return LvlCrit, nil
+	case "neighbors":
+		return LvlNeighbors, nil
+	case "hello":
+		return LvlHello, nil
+	case "disc-proto":
+		return LvlDiscProto, nil
+	case "disc-peer":
+		return LvlDiscPeer, nil
+	case "status":
+		return LvlStatus, nil
+	case "daofork":
+		return LvlDaoFork, nil
+	case "tx-rx":
+		return LvlTxRx, nil
+	case "tx-tx":
+		return LvlTxTx, nil
+	case "newblock-rx":
+		return LvlNewBlockRx, nil
+	case "newblock-tx":
+		return LvlNewBlockTx, nil
+	case "newblockhashes-rx":
+		return LvlNewBlockHashesRx, nil
+	case "newblockhashes-tx":
+		return LvlNewBlockHashesTx, nil
 	default:
 		return LvlDebug, fmt.Errorf("Unknown level: %v", lvlString)
 	}
@@ -123,6 +207,18 @@ type Logger interface {
 	Warn(msg string, ctx ...interface{})
 	Error(msg string, ctx ...interface{})
 	Crit(msg string, ctx ...interface{})
+	Neighbors(msg string, ctx ...interface{})
+	Hello(msg string, ctx ...interface{})
+	DiscProto(msg string, ctx ...interface{})
+	DiscPeer(msg string, ctx ...interface{})
+	Status(msg string, ctx ...interface{})
+	DaoFork(msg string, ctx ...interface{})
+	TxRx(msg string, ctx ...interface{})
+	TxTx(msg string, ctx ...interface{})
+	NewBlockRx(msg string, ctx ...interface{})
+	NewBlockTx(msg string, ctx ...interface{})
+	NewBlockHashesRx(msg string, ctx ...interface{})
+	NewBlockHashesTx(msg string, ctx ...interface{})
 }
 
 type logger struct {
@@ -184,6 +280,54 @@ func (l *logger) Error(msg string, ctx ...interface{}) {
 func (l *logger) Crit(msg string, ctx ...interface{}) {
 	l.write(msg, LvlCrit, ctx)
 	os.Exit(1)
+}
+
+func (l *logger) Neighbors(msg string, ctx ...interface{}) {
+	l.write(msg, LvlNeighbors, ctx)
+}
+
+func (l *logger) Hello(msg string, ctx ...interface{}) {
+	l.write(msg, LvlHello, ctx)
+}
+
+func (l *logger) DiscProto(msg string, ctx ...interface{}) {
+	l.write(msg, LvlDiscProto, ctx)
+}
+
+func (l *logger) DiscPeer(msg string, ctx ...interface{}) {
+	l.write(msg, LvlDiscPeer, ctx)
+}
+
+func (l *logger) Status(msg string, ctx ...interface{}) {
+	l.write(msg, LvlStatus, ctx)
+}
+
+func (l *logger) DaoFork(msg string, ctx ...interface{}) {
+	l.write(msg, LvlDaoFork, ctx)
+}
+
+func (l *logger) TxRx(msg string, ctx ...interface{}) {
+	l.write(msg, LvlTxRx, ctx)
+}
+
+func (l *logger) TxTx(msg string, ctx ...interface{}) {
+	l.write(msg, LvlTxTx, ctx)
+}
+
+func (l *logger) NewBlockRx(msg string, ctx ...interface{}) {
+	l.write(msg, LvlNewBlockRx, ctx)
+}
+
+func (l *logger) NewBlockTx(msg string, ctx ...interface{}) {
+	l.write(msg, LvlNewBlockTx, ctx)
+}
+
+func (l *logger) NewBlockHashesRx(msg string, ctx ...interface{}) {
+	l.write(msg, LvlNewBlockHashesRx, ctx)
+}
+
+func (l *logger) NewBlockHashesTx(msg string, ctx ...interface{}) {
+	l.write(msg, LvlNewBlockHashesTx, ctx)
 }
 
 func (l *logger) GetHandler() Handler {

--- a/log/logger.go
+++ b/log/logger.go
@@ -31,6 +31,7 @@ const (
 	LvlTxData
 	LvlTxRx
 	LvlTxTx
+	LvlNewBlockData
 	LvlNewBlockRx
 	LvlNewBlockTx
 	LvlNewBlockHashesRx
@@ -70,6 +71,8 @@ func (l Lvl) AlignedString() string {
 		return "TXRX"
 	case LvlTxTx:
 		return "TXTX"
+	case LvlNewBlockData:
+		return "NBDATA"
 	case LvlNewBlockRx:
 		return "NBRX"
 	case LvlNewBlockTx:
@@ -116,6 +119,8 @@ func (l Lvl) String() string {
 		return "tx-rx"
 	case LvlTxTx:
 		return "tx-tx"
+	case LvlNewBlockData:
+		return "newblock-data"
 	case LvlNewBlockRx:
 		return "newblock-rx"
 	case LvlNewBlockTx:
@@ -163,6 +168,8 @@ func LvlFromString(lvlString string) (Lvl, error) {
 		return LvlTxRx, nil
 	case "tx-tx":
 		return LvlTxTx, nil
+	case "newblock-data":
+		return LvlNewBlockData, nil
 	case "newblock-rx":
 		return LvlNewBlockRx, nil
 	case "newblock-tx":
@@ -223,6 +230,7 @@ type Logger interface {
 	TxData(msg string, ctx ...interface{})
 	TxRx(msg string, ctx ...interface{})
 	TxTx(msg string, ctx ...interface{})
+	NewBlockData(msg string, ctx ...interface{})
 	NewBlockRx(msg string, ctx ...interface{})
 	NewBlockTx(msg string, ctx ...interface{})
 	NewBlockHashesRx(msg string, ctx ...interface{})
@@ -324,6 +332,10 @@ func (l *logger) TxRx(msg string, ctx ...interface{}) {
 
 func (l *logger) TxTx(msg string, ctx ...interface{}) {
 	l.write(msg, LvlTxTx, ctx)
+}
+
+func (l *logger) NewBlockData(msg string, ctx ...interface{}) {
+	l.write(msg, LvlNewBlockData, ctx)
 }
 
 func (l *logger) NewBlockRx(msg string, ctx ...interface{}) {

--- a/log/root.go
+++ b/log/root.go
@@ -90,6 +90,11 @@ func DaoFork(msg string, ctx ...interface{}) {
 	root.write(msg, LvlDaoFork, ctx)
 }
 
+// TxData is a convenient alias for Root().TxData
+func TxData(msg string, ctx ...interface{}) {
+	root.write(msg, LvlTxData, ctx)
+}
+
 // TxRx is a convenient alias for Root().TxRx
 func TxRx(msg string, ctx ...interface{}) {
 	root.write(msg, LvlTxRx, ctx)

--- a/log/root.go
+++ b/log/root.go
@@ -105,6 +105,11 @@ func TxTx(msg string, ctx ...interface{}) {
 	root.write(msg, LvlTxTx, ctx)
 }
 
+// NewBlockData is a convenient alias for Root().NewBlockData
+func NewBlockData(msg string, ctx ...interface{}) {
+	root.write(msg, LvlNewBlockData, ctx)
+}
+
 // NewBlockRx is a convenient alias for Root().NewBlockRx
 func NewBlockRx(msg string, ctx ...interface{}) {
 	root.write(msg, LvlNewBlockRx, ctx)

--- a/log/root.go
+++ b/log/root.go
@@ -59,3 +59,63 @@ func Crit(msg string, ctx ...interface{}) {
 	root.write(msg, LvlCrit, ctx)
 	os.Exit(1)
 }
+
+// Neighbors is a convenient alias for Root().Neighbors
+func Neighbors(msg string, ctx ...interface{}) {
+	root.write(msg, LvlNeighbors, ctx)
+}
+
+// Hello is a convenient alias for Root().Hello
+func Hello(msg string, ctx ...interface{}) {
+	root.write(msg, LvlHello, ctx)
+}
+
+// DiscProto is a convenient alias for Root().DiscProto
+func DiscProto(msg string, ctx ...interface{}) {
+	root.write(msg, LvlDiscProto, ctx)
+}
+
+// DiscPeer is a convenient alias for Root().DiscPeer
+func DiscPeer(msg string, ctx ...interface{}) {
+	root.write(msg, LvlDiscPeer, ctx)
+}
+
+// Status is a convenient alias for Root().Status
+func Status(msg string, ctx ...interface{}) {
+	root.write(msg, LvlStatus, ctx)
+}
+
+// DaoFork is a convenient alias for Root().DaoFork
+func DaoFork(msg string, ctx ...interface{}) {
+	root.write(msg, LvlDaoFork, ctx)
+}
+
+// TxRx is a convenient alias for Root().TxRx
+func TxRx(msg string, ctx ...interface{}) {
+	root.write(msg, LvlTxRx, ctx)
+}
+
+// TxTx is a convenient alias for Root().TxTx
+func TxTx(msg string, ctx ...interface{}) {
+	root.write(msg, LvlTxTx, ctx)
+}
+
+// NewBlockRx is a convenient alias for Root().NewBlockRx
+func NewBlockRx(msg string, ctx ...interface{}) {
+	root.write(msg, LvlNewBlockRx, ctx)
+}
+
+// NewBlockTx is a convenient alias for Root().NewBlockTx
+func NewBlockTx(msg string, ctx ...interface{}) {
+	root.write(msg, LvlNewBlockTx, ctx)
+}
+
+// NewBlockHashesRx is a convenient alias for Root().NewBlockHashesRx
+func NewBlockHashesRx(msg string, ctx ...interface{}) {
+	root.write(msg, LvlNewBlockHashesRx, ctx)
+}
+
+// NewBlockHashesTx is a convenient alias for Root().NewBlockHashesTx
+func NewBlockHashesTx(msg string, ctx ...interface{}) {
+	root.write(msg, LvlNewBlockHashesTx, ctx)
+}

--- a/node/api.go
+++ b/node/api.go
@@ -63,6 +63,7 @@ func (api *PrivateAdminAPI) Logrotate() error {
 			log.LvlMatchFilterFileHandler(log.LvlDiscPeer, datadir),
 			log.LvlMatchFilterFileHandler(log.LvlStatus, datadir),
 			log.LvlMatchFilterFileHandler(log.LvlDaoFork, datadir),
+			//log.LvlMatchFilterFileHandler(log.LvlTxData, datadir),
 			log.LvlMatchFilterFileHandler(log.LvlTxRx, datadir),
 			//log.LvlMatchFilterFileHandler(log.LvlTxTx, datadir),
 			log.LvlMatchFilterFileHandler(log.LvlNewBlockRx, datadir),

--- a/node/api.go
+++ b/node/api.go
@@ -66,6 +66,7 @@ func (api *PrivateAdminAPI) Logrotate() error {
 			log.LvlMatchFilterFileHandler(log.LvlTxData, datadir),
 			log.LvlMatchFilterFileHandler(log.LvlTxRx, datadir),
 			//log.LvlMatchFilterFileHandler(log.LvlTxTx, datadir),
+			log.LvlMatchFilterFileHandler(log.LvlNewBlockData, datadir),
 			log.LvlMatchFilterFileHandler(log.LvlNewBlockRx, datadir),
 			//log.LvlMatchFilterFileHandler(log.LvlNewBlockTx, datadir),
 			log.LvlMatchFilterFileHandler(log.LvlNewBlockHashesRx, datadir),

--- a/node/api.go
+++ b/node/api.go
@@ -53,11 +53,24 @@ func (api *PrivateAdminAPI) Logrotate() error {
 	)
 	if api.node.config.LogToFile {
 		glogger.SetHandler(log.Must.FileHandler(datadir+"/eth-monitor.log", log.TerminalFormat(false)))
+		log.Root().SetHandler(log.MultiHandler(
+			// default logging for any lvl <= verbosity
+			glogger,
+			// lvl specific logging
+			log.LvlMatchFilterFileHandler(log.LvlNeighbors, datadir),
+			log.LvlMatchFilterFileHandler(log.LvlHello, datadir),
+			log.LvlMatchFilterFileHandler(log.LvlDiscProto, datadir),
+			log.LvlMatchFilterFileHandler(log.LvlDiscPeer, datadir),
+			log.LvlMatchFilterFileHandler(log.LvlStatus, datadir),
+			log.LvlMatchFilterFileHandler(log.LvlDaoFork, datadir),
+			log.LvlMatchFilterFileHandler(log.LvlTxRx, datadir),
+			//log.LvlMatchFilterFileHandler(log.LvlTxTx, datadir),
+			log.LvlMatchFilterFileHandler(log.LvlNewBlockRx, datadir),
+			//log.LvlMatchFilterFileHandler(log.LvlNewBlockTx, datadir),
+			log.LvlMatchFilterFileHandler(log.LvlNewBlockHashesRx, datadir),
+			//log.LvlMatchFilterFileHandler(log.LvlNewBlockHashesTx, datadir),
+		))
 	}
-	log.Root().SetHandler(log.MultiHandler(
-		// default logging for any lvl <= verbosity
-		glogger,
-	))
 	return nil
 }
 

--- a/node/api.go
+++ b/node/api.go
@@ -63,7 +63,7 @@ func (api *PrivateAdminAPI) Logrotate() error {
 			log.LvlMatchFilterFileHandler(log.LvlDiscPeer, datadir),
 			log.LvlMatchFilterFileHandler(log.LvlStatus, datadir),
 			log.LvlMatchFilterFileHandler(log.LvlDaoFork, datadir),
-			//log.LvlMatchFilterFileHandler(log.LvlTxData, datadir),
+			log.LvlMatchFilterFileHandler(log.LvlTxData, datadir),
 			log.LvlMatchFilterFileHandler(log.LvlTxRx, datadir),
 			//log.LvlMatchFilterFileHandler(log.LvlTxTx, datadir),
 			log.LvlMatchFilterFileHandler(log.LvlNewBlockRx, datadir),

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -40,11 +40,12 @@ import (
 // structure, encode the payload into a byte array and create a
 // separate Msg with a bytes.Reader as Payload for each send.
 type Msg struct {
-	Code       uint64
-	Size       uint32 // size of the paylod
-	Payload    io.Reader
-	ReceivedAt time.Time
-	Rtt        float64
+	Code         uint64
+	Size         uint32 // size of the paylod
+	Payload      io.Reader
+	ReceivedAt   time.Time
+	PeerRtt      float64
+	PeerDuration float64
 }
 
 // Decode parses the RLP content of a message into

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -44,6 +44,7 @@ type Msg struct {
 	Size       uint32 // size of the paylod
 	Payload    io.Reader
 	ReceivedAt time.Time
+	Rtt        float64
 }
 
 // Decode parses the RLP content of a message into

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -175,6 +175,10 @@ func newPeer(conn *conn, protocols []Protocol) *Peer {
 	return p
 }
 
+func (p *Peer) ConnFlags() connFlag {
+	return p.rw.flags
+}
+
 func (p *Peer) Log() log.Logger {
 	return p.log
 }
@@ -272,6 +276,8 @@ func (p *Peer) handle(msg Msg) error {
 		// This is the last message. We don't need to discard or
 		// check errors because, the connection will be closed after it.
 		rlp.Decode(msg.Payload, &reason)
+		unixTime := float64(msg.ReceivedAt.UnixNano()) / 1000000000
+		log.DiscPeer(fmt.Sprintf("%f", unixTime), "id", p.ID().String(), "addr", p.RemoteAddr().String(), "conn", p.ConnFlags(), "reason", reason[0])
 		return reason[0]
 	case msg.Code < baseProtocolLength:
 		// ignore other base protocol messages

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"sort"
 	"sync"
 	"time"
@@ -434,12 +435,16 @@ func (p *Peer) Info() *PeerInfo {
 	for _, cap := range p.Caps() {
 		caps = append(caps, cap.String())
 	}
+	rtt := 0.0
+	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+		rtt = p.Srtt()
+	}
 	// Assemble the generic peer metadata
 	info := &PeerInfo{
 		ID:        p.ID().String(),
 		Name:      p.Name(),
 		Caps:      caps,
-		Rtt:       p.Srtt(),
+		Rtt:       rtt,
 		Protocols: make(map[string]interface{}),
 	}
 	info.Network.LocalAddress = p.LocalAddr().String()

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -119,33 +119,34 @@ func (t *rlpx) close(err error) {
 // messages. the protocol handshake is the first authenticated message
 // and also verifies whether the encryption handshake 'worked' and the
 // remote side actually provided the right public key.
-func (t *rlpx) doProtoHandshake(our *protoHandshake) (their *protoHandshake, err error) {
+func (t *rlpx) doProtoHandshake(our *protoHandshake) (their *protoHandshake, receivedAt *time.Time, err error) {
 	// Writing our handshake happens concurrently, we prefer
 	// returning the handshake read error. If the remote side
 	// disconnects us early with a valid reason, we should return it
 	// as the error so it can be tracked elsewhere.
 	werr := make(chan error, 1)
 	go func() { werr <- Send(t.rw, handshakeMsg, our) }()
-	if their, err = readProtocolHandshake(t.rw, our); err != nil {
+	if their, receivedAt, err = readProtocolHandshake(t.rw, our); err != nil {
 		<-werr // make sure the write terminates too
-		return nil, err
+		return nil, receivedAt, err
 	}
 	if err := <-werr; err != nil {
-		return nil, fmt.Errorf("write error: %v", err)
+		return nil, receivedAt, fmt.Errorf("write error: %v", err)
 	}
 	// If the protocol version supports Snappy encoding, upgrade immediately
 	t.rw.snappy = their.Version >= snappyProtocolVersion
 
-	return their, nil
+	return their, receivedAt, nil
 }
 
-func readProtocolHandshake(rw MsgReader, our *protoHandshake) (*protoHandshake, error) {
+func readProtocolHandshake(rw MsgReader, our *protoHandshake) (*protoHandshake, *time.Time, error) {
 	msg, err := rw.ReadMsg()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	msg.ReceivedAt = time.Now()
 	if msg.Size > baseProtocolMaxMsgSize {
-		return nil, fmt.Errorf("message too big")
+		return nil, &msg.ReceivedAt, fmt.Errorf("message too big")
 	}
 	if msg.Code == discMsg {
 		// Disconnect before protocol handshake is valid according to the
@@ -154,19 +155,19 @@ func readProtocolHandshake(rw MsgReader, our *protoHandshake) (*protoHandshake, 
 		// back otherwise. Wrap it in a string instead.
 		var reason [1]DiscReason
 		rlp.Decode(msg.Payload, &reason)
-		return nil, reason[0]
+		return nil, &msg.ReceivedAt, reason[0]
 	}
 	if msg.Code != handshakeMsg {
-		return nil, fmt.Errorf("expected handshake, got %x", msg.Code)
+		return nil, &msg.ReceivedAt, fmt.Errorf("expected handshake, got %x", msg.Code)
 	}
 	var hs protoHandshake
 	if err := msg.Decode(&hs); err != nil {
-		return nil, err
+		return nil, &msg.ReceivedAt, err
 	}
 	if (hs.ID == discover.NodeID{}) {
-		return nil, DiscInvalidIdentity
+		return nil, &msg.ReceivedAt, DiscInvalidIdentity
 	}
-	return &hs, nil
+	return &hs, &msg.ReceivedAt, nil
 }
 
 func (t *rlpx) doEncHandshake(prv *ecdsa.PrivateKey, dial *discover.Node) (discover.NodeID, error) {

--- a/p2p/rlpx_test.go
+++ b/p2p/rlpx_test.go
@@ -175,7 +175,7 @@ func TestProtocolHandshake(t *testing.T) {
 			return
 		}
 
-		phs, err := rlpx.doProtoHandshake(hs0)
+		phs, _, err := rlpx.doProtoHandshake(hs0)
 		if err != nil {
 			t.Errorf("dial side proto handshake error: %v", err)
 			return
@@ -201,7 +201,7 @@ func TestProtocolHandshake(t *testing.T) {
 			return
 		}
 
-		phs, err := rlpx.doProtoHandshake(hs1)
+		phs, _, err := rlpx.doProtoHandshake(hs1)
 		if err != nil {
 			t.Errorf("listen side proto handshake error: %v", err)
 			return
@@ -256,7 +256,7 @@ func TestProtocolHandshakeErrors(t *testing.T) {
 	for i, test := range tests {
 		p1, p2 := MsgPipe()
 		go Send(p1, test.code, test.msg)
-		_, err := readProtocolHandshake(p2, our)
+		_, _, err := readProtocolHandshake(p2, our)
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("test %d: error mismatch: got %q, want %q", i, err, test.err)
 		}

--- a/p2p/rtt_darwin.go
+++ b/p2p/rtt_darwin.go
@@ -11,16 +11,16 @@ import (
 )
 
 // Srtt in seconds (originally milliseconds)
-func (c *conn) Srtt() float64 {
-	tcpInfo := c.GetTCPInfo()
+func (rw *rlpxFrameRW) updateRtt() {
+	tcpInfo := rw.GetTCPInfo()
 	if tcpInfo == nil {
-		return 0.0
+		return
 	}
-	return float64(tcpInfo.Srtt) / 1000
+	rw.rtt = float64(tcpInfo.Srtt) / 1000
 }
 
-func (c *conn) GetTCPInfo() *tcpinfo.TCPConnectionInfo {
-	tcpConn, ok := c.fd.(*net.TCPConn)
+func (rw *rlpxFrameRW) GetTCPInfo() *tcpinfo.TCPConnectionInfo {
+	tcpConn, ok := rw.conn.(*net.TCPConn)
 	if !ok {
 		return nil
 	}

--- a/p2p/rtt_darwin.go
+++ b/p2p/rtt_darwin.go
@@ -11,16 +11,16 @@ import (
 )
 
 // Srtt in seconds (originally milliseconds)
-func (p *Peer) Srtt() float64 {
-	tcpInfo := p.GetTCPInfo()
+func (c *conn) Srtt() float64 {
+	tcpInfo := c.GetTCPInfo()
 	if tcpInfo == nil {
 		return 0.0
 	}
 	return float64(tcpInfo.Srtt) / 1000
 }
 
-func (p *Peer) GetTCPInfo() *tcpinfo.TCPConnectionInfo {
-	tcpConn, ok := (p.rw.fd).(*net.TCPConn)
+func (c *conn) GetTCPInfo() *tcpinfo.TCPConnectionInfo {
+	tcpConn, ok := c.fd.(*net.TCPConn)
 	if !ok {
 		return nil
 	}

--- a/p2p/rtt_linux.go
+++ b/p2p/rtt_linux.go
@@ -11,16 +11,16 @@ import (
 )
 
 // Srtt in seconds (originally microseconds)
-func (c *conn) Srtt() float64 {
-	tcpInfo := c.GetTCPInfo()
+func (rw *rlpxFrameRW) updateRtt() {
+	tcpInfo := rw.GetTCPInfo()
 	if tcpInfo == nil {
-		return 0.0
+		return
 	}
-	return float64(tcpInfo.Rtt) / 1000000
+	rw.rtt = float64(tcpInfo.Rtt) / 1000000
 }
 
-func (c *conn) GetTCPInfo() *tcpinfo.TCPInfo {
-	tcpConn, ok := c.fd.(*net.TCPConn)
+func (rw *rlpxFrameRW) GetTCPInfo() *tcpinfo.TCPInfo {
+	tcpConn, ok := rw.conn.(*net.TCPConn)
 	if !ok {
 		return nil
 	}

--- a/p2p/rtt_linux.go
+++ b/p2p/rtt_linux.go
@@ -11,16 +11,16 @@ import (
 )
 
 // Srtt in seconds (originally microseconds)
-func (p *Peer) Srtt() float64 {
-	tcpInfo := p.GetTCPInfo()
+func (c *conn) Srtt() float64 {
+	tcpInfo := c.GetTCPInfo()
 	if tcpInfo == nil {
 		return 0.0
 	}
 	return float64(tcpInfo.Rtt) / 1000000
 }
 
-func (p *Peer) GetTCPInfo() *tcpinfo.TCPInfo {
-	tcpConn, ok := (p.rw.fd).(*net.TCPConn)
+func (c *conn) GetTCPInfo() *tcpinfo.TCPConnectionInfo {
+	tcpConn, ok := c.fd.(*net.TCPConn)
 	if !ok {
 		return nil
 	}

--- a/p2p/rtt_linux.go
+++ b/p2p/rtt_linux.go
@@ -19,7 +19,7 @@ func (c *conn) Srtt() float64 {
 	return float64(tcpInfo.Rtt) / 1000000
 }
 
-func (c *conn) GetTCPInfo() *tcpinfo.TCPConnectionInfo {
+func (c *conn) GetTCPInfo() *tcpinfo.TCPInfo {
 	tcpConn, ok := c.fd.(*net.TCPConn)
 	if !ok {
 		return nil

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/teamnsrg/go-ethereum/p2p/discv5"
 	"github.com/teamnsrg/go-ethereum/p2p/nat"
 	"github.com/teamnsrg/go-ethereum/p2p/netutil"
+	"runtime"
 )
 
 const (
@@ -784,7 +785,11 @@ func (srv *Server) SetupConn(fd net.Conn, flags connFlag, dialDest *discover.Nod
 		clog.Trace("Failed proto handshake", "err", err)
 		if r, ok := err.(DiscReason); ok {
 			unixTime := float64(receivedAt.UnixNano()) / 1000000000
-			log.DiscProto(fmt.Sprintf("%f", unixTime), "id", c.id.String(), "addr", c.fd.RemoteAddr().String(), "conn", c.flags, "reason", r)
+			rtt := 0.0
+			if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+				rtt = c.Srtt()
+			}
+			log.DiscProto(fmt.Sprintf("%f", unixTime), "id", c.id.String(), "addr", c.fd.RemoteAddr().String(), "conn", c.flags, "rtt", rtt, "reason", r)
 		}
 		c.close(err)
 		return

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -57,8 +57,8 @@ func (c *testTransport) doEncHandshake(prv *ecdsa.PrivateKey, dialDest *discover
 	return c.id, nil
 }
 
-func (c *testTransport) doProtoHandshake(our *protoHandshake) (*protoHandshake, error) {
-	return &protoHandshake{ID: c.id, Name: "test"}, nil
+func (c *testTransport) doProtoHandshake(our *protoHandshake) (*protoHandshake, *time.Time, error) {
+	return &protoHandshake{ID: c.id, Name: "test"}, nil, nil
 }
 
 func (c *testTransport) close(err error) {
@@ -474,12 +474,12 @@ func (c *setupTransport) doEncHandshake(prv *ecdsa.PrivateKey, dialDest *discove
 	c.calls += "doEncHandshake,"
 	return c.id, c.encHandshakeErr
 }
-func (c *setupTransport) doProtoHandshake(our *protoHandshake) (*protoHandshake, error) {
+func (c *setupTransport) doProtoHandshake(our *protoHandshake) (*protoHandshake, *time.Time, error) {
 	c.calls += "doProtoHandshake,"
 	if c.protoHandshakeErr != nil {
-		return nil, c.protoHandshakeErr
+		return nil, nil, c.protoHandshakeErr
 	}
-	return c.phs, nil
+	return c.phs, nil, nil
 }
 func (c *setupTransport) close(err error) {
 	c.calls += "close,"

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -53,12 +53,16 @@ func newTestTransport(id discover.NodeID, fd net.Conn) transport {
 	return &testTransport{id: id, rlpx: wrapped}
 }
 
+func (c *testTransport) Rtt() float64 {
+	return 0.0
+}
+
 func (c *testTransport) doEncHandshake(prv *ecdsa.PrivateKey, dialDest *discover.Node) (discover.NodeID, error) {
 	return c.id, nil
 }
 
-func (c *testTransport) doProtoHandshake(our *protoHandshake) (*protoHandshake, *time.Time, error) {
-	return &protoHandshake{ID: c.id, Name: "test"}, nil, nil
+func (c *testTransport) doProtoHandshake(our *protoHandshake) (*protoHandshake, Msg, error) {
+	return &protoHandshake{ID: c.id, Name: "test"}, Msg{}, nil
 }
 
 func (c *testTransport) close(err error) {
@@ -470,16 +474,20 @@ type setupTransport struct {
 	closeErr error
 }
 
+func (c *setupTransport) Rtt() float64 {
+	return 0.0
+}
+
 func (c *setupTransport) doEncHandshake(prv *ecdsa.PrivateKey, dialDest *discover.Node) (discover.NodeID, error) {
 	c.calls += "doEncHandshake,"
 	return c.id, c.encHandshakeErr
 }
-func (c *setupTransport) doProtoHandshake(our *protoHandshake) (*protoHandshake, *time.Time, error) {
+func (c *setupTransport) doProtoHandshake(our *protoHandshake) (*protoHandshake, Msg, error) {
 	c.calls += "doProtoHandshake,"
 	if c.protoHandshakeErr != nil {
-		return nil, nil, c.protoHandshakeErr
+		return nil, Msg{}, c.protoHandshakeErr
 	}
-	return c.phs, nil, nil
+	return c.phs, Msg{}, nil
 }
 func (c *setupTransport) close(err error) {
 	c.calls += "close,"


### PR DESCRIPTION
Continues from #35 (65cc4c9)
- [x] logtofile
  - [x] tx, txdata
  - [x] newblock
  - [x] newblockhashes
- [x] Peer rtt, duration
- [x] Custom log levels
- [x] Minimize peer disconnects caused by Ethereum message handling failure