### PR TITLE
node-finder storeNodeInfo logic change

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -389,8 +389,8 @@ func (s *Ethereum) Start(srvr *p2p.Server) error {
 	// Set mysql db handle
 	s.protocolManager.db = srvr.DB
 
-	// Set prepared GetRowIDStmt
-	s.protocolManager.getRowIDStmt = srvr.GetRowIDStmt
+	// initiate string replacer
+	s.protocolManager.strReplacer = srvr.StrReplacer
 
 	// Set knownNodeInfos
 	s.protocolManager.knownNodeInfos = srvr.KnownNodeInfos

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"sync"
 	"time"
 
@@ -51,14 +52,11 @@ func errResp(code errCode, format string, v ...interface{}) error {
 }
 
 type ProtocolManager struct {
-	addEthInfoStmt        *sql.Stmt
-	updateEthInfoStmt     *sql.Stmt
-	addEthNodeInfoStmt    *sql.Stmt
-	addDAOForkSupportStmt *sql.Stmt
-	getRowIDStmt          *sql.Stmt
-	knownNodeInfos        *p2p.KnownNodeInfos // information on known nodes
-	db                    *sql.DB             // mysql db handle
-	noMaxPeers            bool                // Flag whether to ignore maxPeers
+	addNodeEthInfoStmt *sql.Stmt
+	knownNodeInfos     *p2p.KnownNodeInfos // information on known nodes
+	db                 *sql.DB             // mysql db handle
+	strReplacer        *strings.Replacer
+	noMaxPeers         bool // Flag whether to ignore maxPeers
 
 	networkId uint64
 

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -32,8 +32,6 @@ import (
 	"github.com/teamnsrg/go-ethereum/params"
 )
 
-var bigTxGas = new(big.Int).SetUint64(params.TxGas)
-
 // Tests that protocol versions and modes of operations are matched up properly.
 func TestProtocolCompatibility(t *testing.T) {
 	// Define the compatibility chart

--- a/eth/node_info.go
+++ b/eth/node_info.go
@@ -1,8 +1,13 @@
 package eth
 
 import (
+	"net"
+	"sort"
+	"strings"
 	"time"
 
+	"fmt"
+	"github.com/teamnsrg/go-ethereum/crypto"
 	"github.com/teamnsrg/go-ethereum/log"
 	"github.com/teamnsrg/go-ethereum/p2p"
 )
@@ -25,51 +30,69 @@ func (pm *ProtocolManager) storeEthNodeInfo(p *peer, statusWrapper *statusDataWr
 		LastStatusAt:    receivedAt,
 	}
 
-	var infoStr string
 	pm.knownNodeInfos.Lock()
-	currentInfo, ok := pm.knownNodeInfos.Infos()[id]
-	pm.knownNodeInfos.Unlock()
-	if !ok {
-		infoStr = newInfo.EthSummary()
+	if currentInfo, ok := pm.knownNodeInfos.Infos()[id]; !ok {
+		if err := pm.fillP2PInfo(p, newInfo); err != nil {
+			pm.knownNodeInfos.Unlock()
+			log.Debug("Failed to fill P2P info", "err", err)
+			log.Info("[STATUS]", "receivedAt", receivedAt, "id", nodeid, "addr", p.RemoteAddr().String(), "conn", p.ConnFlags(), "info", newInfo.EthSummary())
+			return
+		}
+
+		// add new node info to in-memory
+		pm.knownNodeInfos.Infos()[id] = newInfo
 	} else {
 		currentInfo.Lock()
-		defer currentInfo.Unlock()
 		currentInfo.LastStatusAt = newInfo.LastStatusAt
 		currentInfo.LastReceivedTd = newInfo.LastReceivedTd
 		currentInfo.BestHash = newInfo.BestHash
-		if currentInfo.FirstStatusAt == nil {
-			// add new eth info to existing entry
+		if currentInfo.FirstStatusAt == nil || isNewEthNode(currentInfo, newInfo) {
 			currentInfo.FirstStatusAt = newInfo.FirstStatusAt
 			currentInfo.FirstReceivedTd = newInfo.FirstReceivedTd
 			currentInfo.ProtocolVersion = newInfo.ProtocolVersion
 			currentInfo.NetworkId = newInfo.NetworkId
 			currentInfo.GenesisHash = newInfo.GenesisHash
-			if pm.db != nil {
-				pm.addEthInfo(&p2p.KnownNodeInfosWrapper{NodeId: nodeid, Info: currentInfo})
-			}
-		} else if isNewEthNode(currentInfo, newInfo) {
-			// a new entry, including address and DEVp2p info, is added to mysql db
-			currentInfo.FirstStatusAt = newInfo.FirstStatusAt
-			currentInfo.FirstReceivedTd = newInfo.FirstReceivedTd
-			currentInfo.ProtocolVersion = newInfo.ProtocolVersion
-			currentInfo.NetworkId = newInfo.NetworkId
-			currentInfo.GenesisHash = newInfo.GenesisHash
-			if pm.db != nil {
-				pm.addEthNodeInfo(&p2p.KnownNodeInfosWrapper{NodeId: nodeid, Info: currentInfo}, true)
-				if rowId := pm.getRowID(nodeid); rowId > 0 {
-					currentInfo.RowId = rowId
-				}
-			}
-		} else {
-			if pm.db != nil {
-				// update eth info
-				pm.updateEthInfo(&p2p.KnownNodeInfosWrapper{NodeId: nodeid, Info: currentInfo})
-			}
 		}
-		infoStr = currentInfo.EthSummary()
+		currentInfo.Unlock()
+		newInfo = currentInfo
 	}
-	log.Info("[STATUS]", "receivedAt", receivedAt, "id", nodeid, "addr", p.RemoteAddr().String(), "conn", p.ConnFlags(), "info", infoStr)
+	pm.knownNodeInfos.Unlock()
 
+	// update or add a new entry to node_eth_info
+	if pm.db != nil {
+		pm.addNodeEthInfo(&p2p.KnownNodeInfosWrapper{NodeId: nodeid, Info: newInfo}, true)
+	}
+	log.Info("[STATUS]", "receivedAt", receivedAt, "id", nodeid, "addr", p.RemoteAddr().String(), "conn", p.ConnFlags(), "info", newInfo.EthSummary())
+}
+
+func (pm *ProtocolManager) fillP2PInfo(p *peer, newInfo *p2p.Info) error {
+	id := p.ID()
+	newInfo.Keccak256Hash = crypto.Keccak256Hash(id[:]).String()[2:]
+	remoteAddr, ok := p.RemoteAddr().(*net.TCPAddr)
+	if ok {
+		newInfo.IP = remoteAddr.IP.String()
+		newInfo.RemotePort = uint16(remoteAddr.Port)
+	}
+	newInfo.TCPPort = p.TCPPort()
+
+	newInfo.ListenPort = p.ListenPort()
+	newInfo.P2PVersion = p.Version()
+
+	clientId := p.Name()
+	var capsArray []string
+	for _, c := range p.Caps() {
+		capsArray = append(capsArray, c.String())
+	}
+	sort.Strings(capsArray)
+	caps := strings.Join(capsArray, ",")
+
+	// replace unwanted characters
+	if pm.strReplacer == nil {
+		return fmt.Errorf("pm.strReplacer == nil")
+	}
+	newInfo.ClientId = pm.strReplacer.Replace(clientId)
+	newInfo.Caps = pm.strReplacer.Replace(caps)
+	return nil
 }
 
 func isNewEthNode(oldInfo *p2p.Info, newInfo *p2p.Info) bool {
@@ -83,26 +106,18 @@ func (pm *ProtocolManager) storeDAOForkSupportInfo(p *peer, receivedAt time.Time
 
 	pm.knownNodeInfos.Lock()
 	currentInfo, ok := pm.knownNodeInfos.Infos()[id]
-	pm.knownNodeInfos.Unlock()
 	if ok {
 		currentInfo.Lock()
-		defer currentInfo.Unlock()
-		if currentInfo.DAOForkSupport == 0 {
-			// add DAOForkSupport flag to existing entry for the first time
+		if currentInfo.DAOForkSupport == 0 || currentInfo.DAOForkSupport != daoForkSupport {
 			currentInfo.DAOForkSupport = daoForkSupport
-			if pm.db != nil {
-				pm.addDAOForkSupport(&p2p.KnownNodeInfosWrapper{NodeId: nodeid, Info: currentInfo})
-			}
-		} else if currentInfo.DAOForkSupport != daoForkSupport {
-			// DAOForkSupport flag value changed. add a new entry to mysql db
-			currentInfo.DAOForkSupport = daoForkSupport
-			if pm.db != nil {
-				pm.addEthNodeInfo(&p2p.KnownNodeInfosWrapper{NodeId: nodeid, Info: currentInfo}, false)
-				if rowId := pm.getRowID(nodeid); rowId > 0 {
-					currentInfo.RowId = rowId
-				}
-			}
 		}
+		currentInfo.Unlock()
+	}
+	pm.knownNodeInfos.Unlock()
+
+	// update or add a new entry to node_eth_info
+	if pm.db != nil {
+		pm.addNodeEthInfo(&p2p.KnownNodeInfosWrapper{NodeId: nodeid, Info: currentInfo}, false)
 	}
 	log.Info("[DAOFORK]", "receivedAt", receivedAt, "id", nodeid, "addr", p.RemoteAddr().String(), "conn", p.ConnFlags(), "support", daoForkSupport > 0)
 }

--- a/eth/sql_stmt.go
+++ b/eth/sql_stmt.go
@@ -7,16 +7,7 @@ import (
 
 func (pm *ProtocolManager) prepareSqlStmts() error {
 	if pm.db != nil {
-		if err := pm.prepareAddEthInfoStmt(); err != nil {
-			return err
-		}
-		if err := pm.prepareUpdateEthInfoStmt(); err != nil {
-			return err
-		}
-		if err := pm.prepareAddEthNodeInfoStmt(); err != nil {
-			return err
-		}
-		if err := pm.prepareAddDAOForkSupportStmt(); err != nil {
+		if err := pm.prepareAddNodeEthInfoStmt(); err != nil {
 			return err
 		}
 	}
@@ -24,202 +15,62 @@ func (pm *ProtocolManager) prepareSqlStmts() error {
 }
 
 func (pm *ProtocolManager) closeSqlStmts() {
-	if pm.addEthInfoStmt != nil {
-		if err := pm.addEthInfoStmt.Close(); err != nil {
-			log.Error("Failed to close AddEthInfo sql statement", "err", err)
-		} else {
-			log.Trace("Closed AddEthInfo sql statement")
-		}
-	}
-	if pm.updateEthInfoStmt != nil {
-		if err := pm.updateEthInfoStmt.Close(); err != nil {
-			log.Error("Failed to close UpdateEthInfo sql statement", "err", err)
-		} else {
-			log.Trace("Closed UpdateEthInfo sql statement")
-		}
-	}
-	if pm.addEthNodeInfoStmt != nil {
-		if err := pm.addEthNodeInfoStmt.Close(); err != nil {
+	if pm.addNodeEthInfoStmt != nil {
+		if err := pm.addNodeEthInfoStmt.Close(); err != nil {
 			log.Error("Failed to close AddEthNodeInfo sql statement", "err", err)
 		} else {
 			log.Trace("Closed AddEthNodeInfo sql statement")
 		}
 	}
-	if pm.addDAOForkSupportStmt != nil {
-		if err := pm.addDAOForkSupportStmt.Close(); err != nil {
-			log.Error("Failed to close AddDAOForkSupport sql statement", "err", err)
-		} else {
-			log.Trace("Closed AddDAOForkSupport sql statement")
-		}
-	}
 }
 
-func (pm *ProtocolManager) prepareAddEthInfoStmt() error {
+func (pm *ProtocolManager) prepareAddNodeEthInfoStmt() error {
 	pStmt, err := pm.db.Prepare(`
-		UPDATE node_info 
-		SET protocol_version=?, network_id=?, first_received_td=?, last_received_td=?, 
-			best_hash=?, genesis_hash=?, first_status_at=?, last_status_at=?, status_count=1 
-		WHERE id=?
-	`)
-	if err != nil {
-		log.Error("Failed to prepare AddEthInfo sql statement", "err", err)
-		return err
-	} else {
-		log.Trace("Prepared AddEthInfo sql statement")
-		pm.addEthInfoStmt = pStmt
-	}
-	return nil
-}
-
-func (pm *ProtocolManager) addEthInfo(newInfoWrapper *p2p.KnownNodeInfosWrapper) {
-	// exit if no prepared statement
-	if pm.addEthInfoStmt == nil {
-		log.Crit("No prepared statement for AddEthInfo")
-		return
-	}
-
-	nodeid := newInfoWrapper.NodeId
-	newInfo := newInfoWrapper.Info
-	lastStatusAt := newInfo.LastStatusAt.Float64()
-	lastReceivedTd := newInfo.LastReceivedTd.String()
-	_, err := pm.addEthInfoStmt.Exec(newInfo.ProtocolVersion, newInfo.NetworkId, lastReceivedTd, lastReceivedTd,
-		newInfo.BestHash, newInfo.GenesisHash, lastStatusAt, lastStatusAt, newInfo.RowId)
-	if err != nil {
-		log.Error("Failed to execute AddEthInfo sql statement", "id", nodeid[:16], "err", err)
-	} else {
-		log.Trace("Executed AddEthInfo sql statement", "id", nodeid[:16])
-	}
-}
-
-func (pm *ProtocolManager) prepareUpdateEthInfoStmt() error {
-	pStmt, err := pm.db.Prepare(`
-		UPDATE node_info 
-		SET last_received_td=?, best_hash=?, last_status_at=?, status_count=status_count+1 
-		WHERE id=?
-	`)
-
-	if err != nil {
-		log.Error("Failed to prepare UpdateEthInfo sql statement", "err", err)
-		return err
-	} else {
-		log.Trace("Prepared UpdateEthInfo sql statement")
-		pm.updateEthInfoStmt = pStmt
-	}
-	return nil
-}
-
-func (pm *ProtocolManager) updateEthInfo(newInfoWrapper *p2p.KnownNodeInfosWrapper) {
-	// exit if no prepared statement
-	if pm.updateEthInfoStmt == nil {
-		log.Crit("No prepared statement for UpdateEthInfo")
-		return
-	}
-
-	nodeid := newInfoWrapper.NodeId
-	newInfo := newInfoWrapper.Info
-	lastStatusAt := newInfo.LastStatusAt.Float64()
-	lastReceivedTd := newInfo.LastReceivedTd.String()
-	_, err := pm.updateEthInfoStmt.Exec(lastReceivedTd, newInfo.BestHash, lastStatusAt, newInfo.RowId)
-	if err != nil {
-		log.Error("Failed to execute UpdateEthInfo sql statement", "id", nodeid[:16], "err", err)
-	} else {
-		log.Trace("Executed UpdateEthInfo sql statement", "id", nodeid[:16])
-	}
-}
-
-func (pm *ProtocolManager) prepareAddEthNodeInfoStmt() error {
-	pStmt, err := pm.db.Prepare(`
-		INSERT INTO node_info 
+		INSERT INTO node_eth_info 
 			(node_id, ip, tcp_port, remote_port, 
-			 p2p_version, client_id, caps, listen_port, first_hello_at, last_hello_at, 
+			 p2p_version, client_id, caps, listen_port, 
 			 protocol_version, network_id, first_received_td, last_received_td, 
 			 best_hash, genesis_hash, dao_fork, first_status_at, last_status_at, status_count) 
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE 
+			remote_port=VALUES(remote_port), 
+			last_received_td=VALUES(last_received_td), 
+			best_hash=VALUES(best_hash), 
+			dao_fork=VALUES(dao_fork), 
+			last_status_at=VALUES(last_status_at), 
+			status_count=status_count+VALUES(status_count)
 	`)
 	if err != nil {
-		log.Error("Failed to prepare AddEthNodeInfo sql statement", "err", err)
+		log.Error("Failed to prepare AddNodeEthInfo sql statement", "err", err)
 		return err
 	} else {
-		log.Trace("Prepared AddEthNodeInfo sql statement")
-		pm.addEthNodeInfoStmt = pStmt
+		log.Trace("Prepared AddNodeEthInfo sql statement")
+		pm.addNodeEthInfoStmt = pStmt
 	}
 	return nil
 }
 
-func (pm *ProtocolManager) addEthNodeInfo(newInfoWrapper *p2p.KnownNodeInfosWrapper, newStatus bool) {
+func (pm *ProtocolManager) addNodeEthInfo(newInfoWrapper *p2p.KnownNodeInfosWrapper, newStatus bool) {
 	// exit if no prepared statement
-	if pm.addEthNodeInfoStmt == nil {
-		log.Crit("No prepared statement for AddEthNodeInfo")
+	if pm.addNodeEthInfoStmt == nil {
+		log.Crit("No prepared statement for AddNodeEthInfo")
 		return
 	}
 
 	nodeid := newInfoWrapper.NodeId
 	newInfo := newInfoWrapper.Info
-	firstHelloAt := newInfo.FirstHelloAt.Float64()
-	lastHelloAt := newInfo.LastHelloAt.Float64()
 	firstStatusAt := newInfo.FirstStatusAt.Float64()
 	lastStatusAt := newInfo.LastStatusAt.Float64()
 	firstReceivedTd := newInfo.FirstReceivedTd.String()
 	lastReceivedTd := newInfo.LastReceivedTd.String()
-	_, err := pm.addEthNodeInfoStmt.Exec(nodeid, newInfo.IP, newInfo.TCPPort, newInfo.RemotePort,
-		newInfo.P2PVersion, newInfo.ClientId, newInfo.Caps, newInfo.ListenPort, firstHelloAt, lastHelloAt,
+	_, err := pm.addNodeEthInfoStmt.Exec(nodeid, newInfo.IP, newInfo.TCPPort, newInfo.RemotePort,
+		newInfo.P2PVersion, newInfo.ClientId, newInfo.Caps, newInfo.ListenPort,
 		newInfo.ProtocolVersion, newInfo.NetworkId, firstReceivedTd, lastReceivedTd, newInfo.BestHash, newInfo.GenesisHash,
 		newInfo.DAOForkSupport, firstStatusAt, lastStatusAt, boolToInt(newStatus))
 	if err != nil {
-		log.Error("Failed to execute AddEthNodeInfo sql statement", "id", nodeid[:16], "err", err)
+		log.Error("Failed to execute AddNodeEthInfo sql statement", "id", nodeid[:16], "err", err)
 	} else {
-		log.Trace("Executed AddEthNodeInfo sql statement", "id", nodeid[:16])
-	}
-}
-
-func (pm *ProtocolManager) prepareAddDAOForkSupportStmt() error {
-	pStmt, err := pm.db.Prepare(`
-		UPDATE node_info 
-		SET dao_fork=? 
-		WHERE id=?
-	`)
-	if err != nil {
-		log.Error("Failed to prepare AddDAOForkSupport sql statement", "err", err)
-		return err
-	} else {
-		log.Trace("Prepared AddDAOForkSupport sql statement")
-		pm.addDAOForkSupportStmt = pStmt
-	}
-	return nil
-}
-
-func (pm *ProtocolManager) addDAOForkSupport(newInfoWrapper *p2p.KnownNodeInfosWrapper) {
-	// exit if no prepared statement
-	if pm.addDAOForkSupportStmt == nil {
-		log.Crit("No prepared statement for AddDAOForkSupport")
-		return
-	}
-
-	newInfo := newInfoWrapper.Info
-	nodeid := newInfoWrapper.NodeId
-	_, err := pm.addDAOForkSupportStmt.Exec(newInfo.DAOForkSupport, newInfo.RowId)
-	if err != nil {
-		log.Error("Failed to execute AddDAOForkSupport sql statement", "id", nodeid[:16], "err", err)
-	} else {
-		log.Trace("Executed AddDAOForkSupport sql statement", "id", nodeid[:16])
-	}
-}
-
-func (pm *ProtocolManager) getRowID(nodeid string) uint64 {
-	// exit if no prepared statement
-	if pm.getRowIDStmt == nil {
-		log.Crit("No prepared statement for AddEthNodeInfo")
-		return 0
-	}
-
-	var rowId uint64
-	err := pm.getRowIDStmt.QueryRow(nodeid).Scan(&rowId)
-	if err != nil {
-		log.Error("Failed to execute GetRowID sql statement", "id", nodeid[:16], "err", err)
-		return 0
-	} else {
-		log.Trace("Executed GetRowID sql statement", "id", nodeid[:16])
-		return rowId
+		log.Trace("Executed AddNodeEthInfo sql statement", "id", nodeid[:16])
 	}
 }
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -134,6 +134,11 @@ func (p *Peer) ID() discover.NodeID {
 	return p.rw.id
 }
 
+// Version returns the version of the p2p protocol used by the remote peer.
+func (p *Peer) Version() uint64 {
+	return p.rw.version
+}
+
 // Name returns the node name that the remote node advertised.
 func (p *Peer) Name() string {
 	return p.rw.name
@@ -143,6 +148,16 @@ func (p *Peer) Name() string {
 func (p *Peer) Caps() []Cap {
 	// TODO: maybe return copy
 	return p.rw.caps
+}
+
+// ListenPort returns the port number that the remote peer advertised.
+func (p *Peer) ListenPort() uint16 {
+	return p.rw.listenPort
+}
+
+// TCPPort returns the port number that the remote peer advertised through discovery.
+func (p *Peer) TCPPort() uint16 {
+	return p.rw.tcpPort
 }
 
 // RemoteAddr returns the remote address of the network connection.


### PR DESCRIPTION
Continues from #29 (322b014)

- `node_info` table is split into `node_p2p_info` and `node_eth_info`
- changed `storeNodeInfo` logic accordingly