### PR TITLE
case-study pass data to send function correctly

### DIFF
--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -209,7 +209,7 @@ func testGetBlockHeaders(t *testing.T, protocol int) {
 			headers = append(headers, pm.blockchain.GetBlockByHash(hash).Header())
 		}
 		// Send the hash request and verify the response
-		p2p.Send(peer.app, 0x03, tt.query)
+		p2p.SendEthSubproto(peer.app, 0x03, tt.query)
 		if err := p2p.ExpectMsg(peer.app, 0x04, headers); err != nil {
 			t.Errorf("test %d: headers mismatch: %v", i, err)
 		}
@@ -218,7 +218,7 @@ func testGetBlockHeaders(t *testing.T, protocol int) {
 			if origin := pm.blockchain.GetBlockByNumber(tt.query.Origin.Number); origin != nil {
 				tt.query.Origin.Hash, tt.query.Origin.Number = origin.Hash(), 0
 
-				p2p.Send(peer.app, 0x03, tt.query)
+				p2p.SendEthSubproto(peer.app, 0x03, tt.query)
 				if err := p2p.ExpectMsg(peer.app, 0x04, headers); err != nil {
 					t.Errorf("test %d: headers mismatch: %v", i, err)
 				}
@@ -292,7 +292,7 @@ func testGetBlockBodies(t *testing.T, protocol int) {
 			}
 		}
 		// Send the hash request and verify the response
-		p2p.Send(peer.app, 0x05, hashes)
+		p2p.SendEthSubproto(peer.app, 0x05, hashes)
 		if err := p2p.ExpectMsg(peer.app, 0x06, bodies); err != nil {
 			t.Errorf("test %d: bodies mismatch: %v", i, err)
 		}
@@ -350,7 +350,7 @@ func testGetNodeData(t *testing.T, protocol int) {
 			hashes = append(hashes, common.BytesToHash(key))
 		}
 	}
-	p2p.Send(peer.app, 0x0d, hashes)
+	p2p.SendEthSubproto(peer.app, 0x0d, hashes)
 	msg, err := peer.app.ReadMsg()
 	if err != nil {
 		t.Fatalf("failed to read node data response: %v", err)
@@ -444,7 +444,7 @@ func testGetReceipt(t *testing.T, protocol int) {
 		receipts = append(receipts, core.GetBlockReceipts(pm.chaindb, block.Hash(), block.NumberU64()))
 	}
 	// Send the hash request and verify the response
-	p2p.Send(peer.app, 0x0f, hashes)
+	p2p.SendEthSubproto(peer.app, 0x0f, hashes)
 	if err := p2p.ExpectMsg(peer.app, 0x10, receipts); err != nil {
 		t.Errorf("receipts mismatch: %v", err)
 	}
@@ -503,7 +503,7 @@ func testDAOChallenge(t *testing.T, localForked, remoteForked bool, timeout bool
 				block.SetExtra(params.DAOForkBlockExtra)
 			}
 		})
-		if err := p2p.Send(peer.app, BlockHeadersMsg, []*types.Header{blocks[0].Header()}); err != nil {
+		if err := p2p.SendEthSubproto(peer.app, BlockHeadersMsg, []*types.Header{blocks[0].Header()}); err != nil {
 			t.Fatalf("failed to answer challenge: %v", err)
 		}
 		time.Sleep(100 * time.Millisecond) // Sleep to avoid the verification racing with the drops

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -185,7 +185,7 @@ func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, genesi
 	if err := p2p.ExpectMsg(p.app, StatusMsg, msg); err != nil {
 		t.Fatalf("status recv: %v", err)
 	}
-	if err := p2p.Send(p.app, StatusMsg, msg); err != nil {
+	if err := p2p.SendEthSubproto(p.app, StatusMsg, msg); err != nil {
 		t.Fatalf("status send: %v", err)
 	}
 }

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -72,7 +72,7 @@ func testStatusMsgErrors(t *testing.T, protocol int) {
 		p, errc := newTestPeer("peer", protocol, pm, false)
 		// The send call might hang until reset because
 		// the protocol might not read the payload.
-		go p2p.Send(p.app, test.code, test.data)
+		go p2p.SendEthSubproto(p.app, test.code, test.data)
 
 		select {
 		case err := <-errc:
@@ -101,7 +101,7 @@ func testRecvTransactions(t *testing.T, protocol int) {
 	defer p.close()
 
 	tx := newTestTransaction(testAccount, 0, 0)
-	if err := p2p.Send(p.app, TxMsg, []interface{}{tx}); err != nil {
+	if err := p2p.SendEthSubproto(p.app, TxMsg, []interface{}{tx}); err != nil {
 		t.Fatalf("send error: %v", err)
 	}
 	select {

--- a/les/helper_test.go
+++ b/les/helper_test.go
@@ -292,7 +292,7 @@ func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, headNu
 	if err := p2p.ExpectMsg(p.app, StatusMsg, expList); err != nil {
 		t.Fatalf("status recv: %v", err)
 	}
-	if err := p2p.Send(p.app, StatusMsg, sendList); err != nil {
+	if err := p2p.SendDEVp2p(p.app, StatusMsg, sendList); err != nil {
 		t.Fatalf("status send: %v", err)
 	}
 

--- a/les/peer.go
+++ b/les/peer.go
@@ -152,7 +152,7 @@ func sendRequest(w p2p.MsgWriter, msgcode, reqID, cost uint64, data interface{})
 		ReqID uint64
 		Data  interface{}
 	}
-	return p2p.Send(w, msgcode, req{reqID, data})
+	return p2p.SendDEVp2p(w, msgcode, req{reqID, data})
 }
 
 func sendResponse(w p2p.MsgWriter, msgcode, reqID, bv uint64, data interface{}) error {
@@ -160,7 +160,7 @@ func sendResponse(w p2p.MsgWriter, msgcode, reqID, bv uint64, data interface{}) 
 		ReqID, BV uint64
 		Data      interface{}
 	}
-	return p2p.Send(w, msgcode, resp{reqID, bv, data})
+	return p2p.SendDEVp2p(w, msgcode, resp{reqID, bv, data})
 }
 
 func (p *peer) GetRequestCost(msgcode uint64, amount int) uint64 {
@@ -185,7 +185,7 @@ func (p *peer) HasBlock(hash common.Hash, number uint64) bool {
 // SendAnnounce announces the availability of a number of blocks through
 // a hash notification.
 func (p *peer) SendAnnounce(request announceData) error {
-	return p2p.Send(p.rw, AnnounceMsg, request)
+	return p2p.SendDEVp2p(p.rw, AnnounceMsg, request)
 }
 
 // SendBlockHeaders sends a batch of block headers to the remote peer.
@@ -317,7 +317,7 @@ func (p *peer) SendTxs(reqID, cost uint64, txs types.Transactions) error {
 	p.Log().Debug("Fetching batch of transactions", "count", len(txs))
 	switch p.version {
 	case lpv1:
-		return p2p.Send(p.rw, SendTxMsg, txs) // old message format does not include reqID
+		return p2p.SendDEVp2p(p.rw, SendTxMsg, txs) // old message format does not include reqID
 	case lpv2:
 		return sendRequest(p.rw, SendTxV2Msg, reqID, cost, txs)
 	default:
@@ -368,7 +368,7 @@ func (p *peer) sendReceiveHandshake(sendList keyValueList) (keyValueList, error)
 	// Send out own handshake in a new thread
 	errc := make(chan error, 1)
 	go func() {
-		errc <- p2p.Send(p.rw, StatusMsg, sendList)
+		errc <- p2p.SendDEVp2p(p.rw, StatusMsg, sendList)
 	}()
 	// In the mean time retrieve the remote status message
 	msg, err := p.rw.ReadMsg()

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -99,17 +99,6 @@ type MsgReadWriter interface {
 	MsgWriter
 }
 
-// Send writes an RLP-encoded message with the given code.
-// data should encode as an RLP list.
-func Send(w MsgWriter, msgcode uint64, data interface{}) error {
-	size, r, err := rlp.EncodeToReader(data)
-
-	if err != nil {
-		return err
-	}
-	return w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
-}
-
 var empty struct{}
 var dataExcludedMsgs = map[uint64]struct{}{
 	0x02: empty, //TxMsg

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -156,9 +156,9 @@ func SendDEVp2p(w MsgWriter, msgcode uint64, data interface{}, peers ...discover
 	}
 
 	obj := data
-	if d, ok := data.([]DiscReason); ok && msgcode == discMsg {
-		if len(d) > 0 {
-			obj = discReasonToString[d[0]]
+	if dataArr, ok := data.([]interface{}); ok && len(dataArr) > 0 {
+		if d, ok := dataArr[0].(DiscReason); ok && msgcode == discMsg {
+			obj = discReasonToString[d]
 		}
 	}
 	log.Proto(">>"+msgType, "obj", obj, "size", size, "peer", peer)

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -168,14 +168,14 @@ func SendDEVp2p(w MsgWriter, msgcode uint64, data interface{}, peers ...discover
 // SendItems writes an RLP with the given code and data elements.
 // For a call such as:
 //
-//    SendItems(w, code, e1, e2, e3)
+//    SendItems(id, w, code, e1, e2, e3)
 //
 // the message payload will be an RLP list containing the items:
 //
 //    [e1, e2, e3]
 //
-func SendItems(w MsgWriter, msgcode uint64, elems ...interface{}) error {
-	return SendDEVp2p(w, msgcode, elems)
+func SendItems(id discover.NodeID, w MsgWriter, msgcode uint64, elems ...interface{}) error {
+	return SendDEVp2p(w, msgcode, elems, id)
 }
 
 // netWrapper wraps a MsgReadWriter with locks around

--- a/p2p/message_test.go
+++ b/p2p/message_test.go
@@ -30,8 +30,8 @@ import (
 func ExampleMsgPipe() {
 	rw1, rw2 := MsgPipe()
 	go func() {
-		Send(rw1, 8, [][]byte{{0, 0}})
-		Send(rw1, 5, [][]byte{{1, 1}})
+		SendDEVp2p(rw1, 8, [][]byte{{0, 0}})
+		SendDEVp2p(rw1, 5, [][]byte{{1, 1}})
 		rw1.Close()
 	}()
 

--- a/p2p/message_test.go
+++ b/p2p/message_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"github.com/teamnsrg/go-ethereum/p2p/discover"
 	"io"
 	"runtime"
 	"strings"
@@ -55,7 +56,7 @@ loop:
 		rw1, rw2 := MsgPipe()
 		done := make(chan struct{})
 		go func() {
-			if err := SendItems(rw1, 1); err == nil {
+			if err := SendItems(discover.NodeID{}, rw1, 1); err == nil {
 				t.Error("EncodeMsg returned nil error")
 			} else if err != ErrPipeClosed {
 				t.Errorf("EncodeMsg returned wrong error: got %v, want %v", err, ErrPipeClosed)

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -275,7 +275,7 @@ func (p *Peer) pingLoop() {
 	for {
 		select {
 		case <-ping.C:
-			if err := SendItems(p.ID(), p.rw, pingMsg, make([]interface{}, 0)); err != nil {
+			if err := SendItems(p.ID(), p.rw, pingMsg); err != nil {
 				p.protoErr <- err
 				return
 			}
@@ -308,7 +308,7 @@ func (p *Peer) handle(msg Msg) error {
 	case msg.Code == pingMsg:
 		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
 		msg.Discard()
-		go SendItems(p.ID(), p.rw, pongMsg, make([]interface{}, 0))
+		go SendItems(p.ID(), p.rw, pongMsg)
 	case msg.Code == pongMsg:
 		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
 		msg.Discard()

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -53,7 +53,7 @@ const (
 	peersMsg     = 0x05
 )
 
-var devp2pCodeToString = [...]string{
+var devp2pCodeToString = map[uint64]string{
 	handshakeMsg: "DEVP2P_HELLO",
 	discMsg:      "DEVP2P_DISC",
 	pingMsg:      "DEVP2P_PING",
@@ -62,7 +62,7 @@ var devp2pCodeToString = [...]string{
 	peersMsg:     "DEVP2P_PEERS",
 }
 
-var ethCodeToString = [...]string{
+var ethCodeToString = map[uint64]string{
 	// Protocol messages belonging to eth/62
 	0x00: "ETH_STATUS",
 	0x01: "ETH_NEW_BLOCK_HASHES",

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -275,7 +275,7 @@ func (p *Peer) pingLoop() {
 	for {
 		select {
 		case <-ping.C:
-			if err := SendItems(p.rw, pingMsg, make([]interface{}, 0)); err != nil {
+			if err := SendItems(p.ID(), p.rw, pingMsg, make([]interface{}, 0)); err != nil {
 				p.protoErr <- err
 				return
 			}
@@ -308,7 +308,7 @@ func (p *Peer) handle(msg Msg) error {
 	case msg.Code == pingMsg:
 		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
 		msg.Discard()
-		go SendItems(p.rw, pongMsg, make([]interface{}, 0))
+		go SendItems(p.ID(), p.rw, pongMsg, make([]interface{}, 0))
 	case msg.Code == pongMsg:
 		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
 		msg.Discard()

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -275,7 +275,7 @@ func (p *Peer) pingLoop() {
 	for {
 		select {
 		case <-ping.C:
-			if err := SendDEVp2p(p.rw, pingMsg, make([]interface{}, 0), p.ID()); err != nil {
+			if err := SendItems(p.rw, pingMsg, make([]interface{}, 0)); err != nil {
 				p.protoErr <- err
 				return
 			}
@@ -308,7 +308,7 @@ func (p *Peer) handle(msg Msg) error {
 	case msg.Code == pingMsg:
 		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
 		msg.Discard()
-		go SendDEVp2p(p.rw, pongMsg, make([]interface{}, 0), p.ID())
+		go SendItems(p.rw, pongMsg, make([]interface{}, 0))
 	case msg.Code == pongMsg:
 		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
 		msg.Discard()

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -84,9 +84,9 @@ func TestPeerProtoReadMsg(t *testing.T) {
 	closer, rw, _, errc := testPeer([]Protocol{proto})
 	defer closer()
 
-	Send(rw, baseProtocolLength+2, []uint{1})
-	Send(rw, baseProtocolLength+3, []uint{2})
-	Send(rw, baseProtocolLength+4, []uint{3})
+	SendDEVp2p(rw, baseProtocolLength+2, []uint{1})
+	SendDEVp2p(rw, baseProtocolLength+3, []uint{2})
+	SendDEVp2p(rw, baseProtocolLength+4, []uint{3})
 
 	select {
 	case err := <-errc:

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -110,7 +110,7 @@ func (t *rlpx) close(err error, peer discover.NodeID) {
 	if t.rw != nil {
 		if r, ok := err.(DiscReason); ok && r != DiscNetworkError {
 			t.fd.SetWriteDeadline(time.Now().Add(discWriteTimeout))
-			SendDEVp2p(t.rw, discMsg, r, peer)
+			SendItems(t.rw, discMsg, r)
 		}
 	}
 	t.fd.Close()

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -103,14 +103,14 @@ func (t *rlpx) WriteMsg(msg Msg) error {
 	return t.rw.WriteMsg(msg)
 }
 
-func (t *rlpx) close(err error, peer discover.NodeID) {
+func (t *rlpx) close(err error, id discover.NodeID) {
 	t.wmu.Lock()
 	defer t.wmu.Unlock()
 	// Tell the remote end why we're disconnecting if possible.
 	if t.rw != nil {
 		if r, ok := err.(DiscReason); ok && r != DiscNetworkError {
 			t.fd.SetWriteDeadline(time.Now().Add(discWriteTimeout))
-			SendItems(t.rw, discMsg, r)
+			SendItems(id, t.rw, discMsg, r)
 		}
 	}
 	t.fd.Close()
@@ -120,14 +120,14 @@ func (t *rlpx) close(err error, peer discover.NodeID) {
 // messages. the protocol handshake is the first authenticated message
 // and also verifies whether the encryption handshake 'worked' and the
 // remote side actually provided the right public key.
-func (t *rlpx) doProtoHandshake(our *protoHandshake, peer discover.NodeID) (their *protoHandshake, err error) {
+func (t *rlpx) doProtoHandshake(our *protoHandshake, id discover.NodeID) (their *protoHandshake, err error) {
 	// Writing our handshake happens concurrently, we prefer
 	// returning the handshake read error. If the remote side
 	// disconnects us early with a valid reason, we should return it
 	// as the error so it can be tracked elsewhere.
 	werr := make(chan error, 1)
-	go func() { werr <- SendDEVp2p(t.rw, handshakeMsg, our, peer) }()
-	if their, err = readProtocolHandshake(t.rw, peer); err != nil {
+	go func() { werr <- SendDEVp2p(t.rw, handshakeMsg, our, id) }()
+	if their, err = readProtocolHandshake(t.rw, id); err != nil {
 		<-werr // make sure the write terminates too
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (t *rlpx) doProtoHandshake(our *protoHandshake, peer discover.NodeID) (thei
 	return their, nil
 }
 
-func readProtocolHandshake(rw MsgReader, peer discover.NodeID) (*protoHandshake, error) {
+func readProtocolHandshake(rw MsgReader, id discover.NodeID) (*protoHandshake, error) {
 	msg, err := rw.ReadMsg()
 	if err != nil {
 		return nil, err
@@ -155,21 +155,21 @@ func readProtocolHandshake(rw MsgReader, peer discover.NodeID) (*protoHandshake,
 		// back otherwise. Wrap it in a string instead.
 		var reason [1]DiscReason
 		rlp.Decode(msg.Payload, &reason)
-		log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", discReasonToString[reason[0]], "size", int(msg.Size), "peer", peer)
+		log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", discReasonToString[reason[0]], "size", int(msg.Size), "peer", id)
 		return nil, reason[0]
 	}
 	if msg.Code != handshakeMsg {
 		var emptyMsgObj []interface{}
 		if int(msg.Code) < len(devp2pCodeToString) {
-			log.Proto("<<UNEXPECTED_"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", peer)
+			log.Proto("<<UNEXPECTED_"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", id)
 		} else {
-			log.Proto(fmt.Sprintf("<<UNEXPECTED_UNKNOWN_%v", msg.Code), "obj", "<OMITTED>", "size", int(msg.Size), "peer", peer)
+			log.Proto(fmt.Sprintf("<<UNEXPECTED_UNKNOWN_%v", msg.Code), "obj", "<OMITTED>", "size", int(msg.Size), "peer", id)
 		}
 		return nil, fmt.Errorf("expected handshake, got %x", msg.Code)
 	}
 	var hs protoHandshake
 	if err := msg.Decode(&hs); err != nil {
-		log.Proto("<<FAIL_"+devp2pCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", peer)
+		log.Proto("<<FAIL_"+devp2pCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", id)
 		return nil, err
 	}
 

--- a/p2p/rlpx_test.go
+++ b/p2p/rlpx_test.go
@@ -220,7 +220,6 @@ func TestProtocolHandshake(t *testing.T) {
 }
 
 func TestProtocolHandshakeErrors(t *testing.T) {
-	our := &protoHandshake{Version: 3, Caps: []Cap{{"foo", 2}, {"bar", 3}}, Name: "quux"}
 	tests := []struct {
 		code uint64
 		msg  interface{}
@@ -255,8 +254,8 @@ func TestProtocolHandshakeErrors(t *testing.T) {
 
 	for i, test := range tests {
 		p1, p2 := MsgPipe()
-		go Send(p1, test.code, test.msg)
-		_, err := readProtocolHandshake(p2, our)
+		go SendDEVp2p(p1, test.code, test.msg)
+		_, err := readProtocolHandshake(p2, discover.NodeID{})
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("test %d: error mismatch: got %q, want %q", i, err, test.err)
 		}
@@ -281,7 +280,7 @@ ba628a4ba590cb43f7848f41c4382885
 `)
 
 	// Check WriteMsg. This puts a message into the buffer.
-	if err := Send(rw, 8, []uint{1, 2, 3, 4}); err != nil {
+	if err := SendDEVp2p(rw, 8, []uint{1, 2, 3, 4}); err != nil {
 		t.Fatalf("WriteMsg error: %v", err)
 	}
 	written := buf.Bytes()
@@ -353,7 +352,7 @@ func TestRLPXFrameRW(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		// write message into conn buffer
 		wmsg := []interface{}{"foo", "bar", strings.Repeat("test", i)}
-		err := Send(rw1, uint64(i), wmsg)
+		err := SendDEVp2p(rw1, uint64(i), wmsg)
 		if err != nil {
 			t.Fatalf("WriteMsg error (i=%d): %v", i, err)
 		}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -206,7 +206,7 @@ type conn struct {
 type transport interface {
 	// The two handshakes.
 	doEncHandshake(prv *ecdsa.PrivateKey, dialDest *discover.Node) (discover.NodeID, error)
-	doProtoHandshake(our *protoHandshake, peer discover.NodeID) (*protoHandshake, error)
+	doProtoHandshake(our *protoHandshake, id discover.NodeID) (*protoHandshake, error)
 	// The MsgReadWriter can only be used after the encryption
 	// handshake has completed. The code uses conn.id to track this
 	// by setting it to a non-nil value after the encryption handshake.
@@ -214,7 +214,7 @@ type transport interface {
 	// transports must provide Close because we use MsgPipe in some of
 	// the tests. Closing the actual network connection doesn't do
 	// anything in those tests because NsgPipe doesn't use it.
-	close(err error, peer discover.NodeID)
+	close(err error, id discover.NodeID)
 }
 
 func (c *conn) String() string {

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -56,11 +56,11 @@ func (c *testTransport) doEncHandshake(prv *ecdsa.PrivateKey, dialDest *discover
 	return c.id, nil
 }
 
-func (c *testTransport) doProtoHandshake(our *protoHandshake) (*protoHandshake, error) {
+func (c *testTransport) doProtoHandshake(our *protoHandshake, peer discover.NodeID) (*protoHandshake, error) {
 	return &protoHandshake{ID: c.id, Name: "test"}, nil
 }
 
-func (c *testTransport) close(err error) {
+func (c *testTransport) close(err error, peer discover.NodeID) {
 	c.rlpx.fd.Close()
 	c.closeErr = err
 }
@@ -460,14 +460,14 @@ func (c *setupTransport) doEncHandshake(prv *ecdsa.PrivateKey, dialDest *discove
 	c.calls += "doEncHandshake,"
 	return c.id, c.encHandshakeErr
 }
-func (c *setupTransport) doProtoHandshake(our *protoHandshake) (*protoHandshake, error) {
+func (c *setupTransport) doProtoHandshake(our *protoHandshake, peer discover.NodeID) (*protoHandshake, error) {
 	c.calls += "doProtoHandshake,"
 	if c.protoHandshakeErr != nil {
 		return nil, c.protoHandshakeErr
 	}
 	return c.phs, nil
 }
-func (c *setupTransport) close(err error) {
+func (c *setupTransport) close(err error, peer discover.NodeID) {
 	c.calls += "close,"
 	c.closeErr = err
 }

--- a/p2p/simulations/examples/ping-pong.go
+++ b/p2p/simulations/examples/ping-pong.go
@@ -154,7 +154,7 @@ func (p *pingPongService) Run(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
 	go func() {
 		for range time.Tick(10 * time.Second) {
 			log.Info("sending ping")
-			if err := p2p.Send(rw, pingMsgCode, "PING"); err != nil {
+			if err := p2p.SendDEVp2p(rw, pingMsgCode, "PING"); err != nil {
 				errC <- err
 				return
 			}
@@ -176,7 +176,7 @@ func (p *pingPongService) Run(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
 			atomic.AddInt64(&p.received, 1)
 			if msg.Code == pingMsgCode {
 				log.Info("sending pong")
-				go p2p.Send(rw, pongMsgCode, "PONG")
+				go p2p.SendDEVp2p(rw, pongMsgCode, "PONG")
 			}
 		}
 	}()

--- a/p2p/simulations/http_test.go
+++ b/p2p/simulations/http_test.go
@@ -125,7 +125,7 @@ func (t *testService) Stop() error {
 // message with the given code
 func (t *testService) handshake(rw p2p.MsgReadWriter, code uint64) error {
 	errc := make(chan error, 2)
-	go func() { errc <- p2p.Send(rw, code, struct{}{}) }()
+	go func() { errc <- p2p.SendDEVp2p(rw, code, struct{}{}) }()
 	go func() { errc <- p2p.ExpectMsg(rw, code, struct{}{}) }()
 	for i := 0; i < 2; i++ {
 		if err := <-errc; err != nil {

--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -316,7 +316,7 @@ func (self *bzz) handleStatus() (err error) {
 		},
 	}
 
-	err = p2p.Send(self.rw, statusMsg, handshake)
+	err = p2p.SendDEVp2p(self.rw, statusMsg, handshake)
 	if err != nil {
 		return err
 	}
@@ -502,7 +502,7 @@ func (self *bzz) send(msg uint64, data interface{}) error {
 		return fmt.Errorf("network write blocked")
 	}
 	log.Trace(fmt.Sprintf("-> %v: %v (%T) to %v", msg, data, data, self))
-	err := p2p.Send(self.rw, msg, data)
+	err := p2p.SendDEVp2p(self.rw, msg, data)
 	if err != nil {
 		self.Drop()
 	}


### PR DESCRIPTION
I accidentally found the cause while trying to fix the test cases (`rlpx_test.go:TestProtocolHandshake`).
It was due to misuse of interface and slice of interfaces when calling `SendDEVp2p` and `SendEthSubproto`.

- The `Send` function is removed to avoid confusion. All codes, including tests, should use either `SendDEVp2p` or `SendEthSubProto`.
  - Any part of `p2p` package that previously used `Send` now use `SendDEVp2p`
  - Any part of `eth` package that previously used `Send` now use `SendEthSubproto`
  - Any part of all other packages that previously used `Send` now use `SendDEVp2p` (as logging is the only difference between the two).
- `SendItems` should call `SendDEVp2p`. It is used by only `p2p`. Anywhere that previously used `SendItems` should continue to use it, not the other functions.