### PR TITLE
node-finder log messages

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -123,6 +123,9 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
 	}
 
 	// Apply flags.
+	if ctx.GlobalBool(utils.LogToFileFlag.Name) {
+		cfg.Node.LogToFile = true
+	}
 	utils.SetNodeConfig(ctx, &cfg.Node)
 	stack, err := node.New(&cfg.Node)
 	if err != nil {

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -66,15 +66,16 @@ var AppHelpFlagGroups = []flagGroup{
 	{
 		Name: "NODE FINDER",
 		Flags: []cli.Flag{
+			utils.MaxDialFlag,
+			utils.NoMaxPeersFlag,
+			utils.MaxAcceptConnsFlag,
+			utils.MaxNumFileFlag,
+			utils.BlacklistFlag,
+			utils.DialFreqFlag,
 			utils.MySQLFlag,
 			utils.BackupSQLFlag,
 			utils.ResetSQLFlag,
-			utils.MaxNumFileFlag,
-			utils.MaxDialFlag,
-			utils.MaxAcceptConnsFlag,
-			utils.NoMaxPeersFlag,
-			utils.DialFreqFlag,
-			utils.BlacklistFlag,
+			utils.LogToFileFlag,
 		},
 	},
 	{

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -347,7 +347,9 @@ DEPRECATED: use 'swarm db clean'.
 	app.Flags = append(app.Flags, debug.Flags...)
 	app.Before = func(ctx *cli.Context) error {
 		runtime.GOMAXPROCS(runtime.NumCPU())
-		return debug.Setup(ctx)
+		glogger, err := debug.Setup(nil, ctx)
+		log.Root().SetHandler(glogger)
+		return err
 	}
 	app.After = func(ctx *cli.Context) error {
 		debug.Exit()

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -112,6 +112,34 @@ func NewApp(gitCommit, usage string) *cli.App {
 
 var (
 	// Node Finder settings
+	MaxDialFlag = cli.IntFlag{
+		Name:  "maxdial",
+		Usage: "Maximum number of concurrently dialing outbound connections",
+		Value: 16,
+	}
+	NoMaxPeersFlag = cli.BoolFlag{
+		Name:  "nomaxpeers",
+		Usage: "Ignore/overwrite MaxPeers to allow unlimited number of peer connections",
+	}
+	MaxAcceptConnsFlag = cli.IntFlag{
+		Name:  "maxacceptconns",
+		Usage: "Maximum number of concurrently handshaking inbound connections",
+		Value: 50,
+	}
+	MaxNumFileFlag = cli.Uint64Flag{
+		Name:  "maxnumfile",
+		Usage: "Maximum file descriptor allowance of this process (try 1048576)",
+		Value: 2048,
+	}
+	BlacklistFlag = cli.StringFlag{
+		Name:  "blacklist",
+		Usage: "Reject network communication from/to the given IP networks (CIDR masks)",
+	}
+	DialFreqFlag = cli.IntFlag{
+		Name:  "dialfreq",
+		Usage: "Frequency of re-dialing static nodes (in seconds)",
+		Value: 30,
+	}
 	MySQLFlag = cli.StringFlag{
 		Name:  "mysql",
 		Usage: "Connects to the specified database and update node information (username:password@tcp(ip:port)/db)",
@@ -124,33 +152,9 @@ var (
 		Name:  "resetsql",
 		Usage: "Makes a backup of the current MySQL db tables and resets them (if set, backupsql is automatically set)",
 	}
-	MaxNumFileFlag = cli.Uint64Flag{
-		Name:  "maxnumfile",
-		Usage: "Maximum file descriptor allowance of this process (try 1048576)",
-		Value: 2048,
-	}
-	MaxDialFlag = cli.IntFlag{
-		Name:  "maxdial",
-		Usage: "Maximum number of concurrently dialing outbound connections",
-		Value: 16,
-	}
-	MaxAcceptConnsFlag = cli.IntFlag{
-		Name:  "maxacceptconns",
-		Usage: "Maximum number of concurrently handshaking inbound connections",
-		Value: 50,
-	}
-	NoMaxPeersFlag = cli.BoolFlag{
-		Name:  "nomaxpeers",
-		Usage: "Ignore/overwrite MaxPeers to allow unlimited number of peer connections",
-	}
-	DialFreqFlag = cli.IntFlag{
-		Name:  "dialfreq",
-		Usage: "Frequency of re-dialing static nodes (in seconds)",
-		Value: 30,
-	}
-	BlacklistFlag = cli.StringFlag{
-		Name:  "blacklist",
-		Usage: "Reject network communication from/to the given IP networks (CIDR masks)",
+	LogToFileFlag = cli.BoolFlag{
+		Name:  "logtofile",
+		Usage: "Write log to node-finder.log instead of stderr",
 	}
 	// General settings
 	DataDirFlag = DirectoryFlag{
@@ -827,6 +831,15 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	setBootstrapNodes(ctx, cfg)
 	setBootstrapNodesV5(ctx, cfg)
 
+	if ctx.GlobalIsSet(NoMaxPeersFlag.Name) {
+		cfg.NoMaxPeers = true
+	}
+	if ctx.GlobalIsSet(MaxAcceptConnsFlag.Name) {
+		cfg.MaxAcceptConns = ctx.GlobalInt(MaxAcceptConnsFlag.Name)
+	}
+	if ctx.GlobalIsSet(DialFreqFlag.Name) {
+		cfg.DialFreq = ctx.GlobalInt(DialFreqFlag.Name)
+	}
 	if ctx.GlobalIsSet(MySQLFlag.Name) {
 		cfg.MySQLName = ctx.GlobalString(MySQLFlag.Name)
 	}
@@ -840,15 +853,7 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	if ctx.GlobalIsSet(MaxDialFlag.Name) {
 		cfg.MaxDial = ctx.GlobalInt(MaxDialFlag.Name)
 	}
-	if ctx.GlobalIsSet(MaxAcceptConnsFlag.Name) {
-		cfg.MaxAcceptConns = ctx.GlobalInt(MaxAcceptConnsFlag.Name)
-	}
-	if ctx.GlobalIsSet(NoMaxPeersFlag.Name) {
-		cfg.NoMaxPeers = true
-	}
-	if ctx.GlobalIsSet(DialFreqFlag.Name) {
-		cfg.DialFreq = ctx.GlobalInt(DialFreqFlag.Name)
-	}
+
 	if ctx.GlobalIsSet(MaxPeersFlag.Name) {
 		cfg.MaxPeers = ctx.GlobalInt(MaxPeersFlag.Name)
 	}

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -255,7 +255,7 @@ func TestPrettyPrint(t *testing.T) {
 	// Define some specially formatted fields
 	var (
 		one   = jsre.NumberColor("1")
-		two   = jsre.StringColor("\"two\"")
+		two   = jsre.StringColor("two")
 		three = jsre.NumberColor("3")
 		null  = jsre.SpecialColor("null")
 		fun   = jsre.FunctionColor("function()")

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -16,13 +16,6 @@
 
 package eth
 
-const (
-
-	// This is the target size for the packs of transactions sent by txsyncLoop.
-	// A pack can get larger than this if a single transactions exceeds this size.
-	txsyncPackSize = 100 * 1024
-)
-
 // syncer is responsible for periodically synchronising with the network, both
 // downloading hashes and blocks as well as handling the announcement handler.
 func (pm *ProtocolManager) syncer() {

--- a/internal/jsre/pretty.go
+++ b/internal/jsre/pretty.go
@@ -92,7 +92,7 @@ func (ctx ppctx) printValue(v otto.Value, level int, inArray bool) {
 		fmt.Fprint(ctx.w, SpecialColor("undefined"))
 	case v.IsString():
 		s, _ := v.ToString()
-		fmt.Fprint(ctx.w, StringColor("%q", s))
+		fmt.Fprint(ctx.w, StringColor("%s", s))
 	case v.IsBoolean():
 		b, _ := v.ToBoolean()
 		fmt.Fprint(ctx.w, SpecialColor("%t", b))

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -159,6 +159,20 @@ web3._extend({
 			name: 'stopWS',
 			call: 'admin_stopWS'
 		}),
+		new web3._extend.Method({
+			name: 'logrotate',
+			call: 'admin_logrotate'
+		}),
+		new web3._extend.Method({
+			name: 'setDialFreq',
+			call: 'admin_setDialFreq',
+			params: 1,
+		}),
+		new web3._extend.Method({
+			name: 'addBlackList',
+			call: 'admin_addBlacklist',
+			params: 1,
+		}),
 	],
 	properties: [
 		new web3._extend.Property({
@@ -176,6 +190,14 @@ web3._extend({
 		new web3._extend.Property({
 			name: 'datadir',
 			getter: 'admin_datadir'
+		}),
+		new web3._extend.Property({
+			name: 'dialFreq',
+			getter: 'admin_dialFreq'
+		}),
+		new web3._extend.Property({
+			name: 'blacklist',
+			getter: 'admin_blacklist'
 		}),
 	]
 });

--- a/log/format.go
+++ b/log/format.go
@@ -82,6 +82,8 @@ func TerminalFormat(usecolor bool) Format {
 				color = 36
 			case LvlTrace:
 				color = 34
+			default:
+				color = 37
 			}
 		}
 
@@ -105,15 +107,15 @@ func TerminalFormat(usecolor bool) Format {
 
 			// Assemble and print the log heading
 			if color > 0 {
-				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m|%s|%s|[%s]|%s", color, lvl, r.Time.Format(nanoTermTimeFormat), unixTime, location, r.Msg)
+				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m|%s|[%s]|%s", color, lvl, unixTime, location, r.Msg)
 			} else {
-				fmt.Fprintf(b, "%s|%s|%s|[%s]|%s", lvl, r.Time.Format(nanoTermTimeFormat), unixTime, location, r.Msg)
+				fmt.Fprintf(b, "%s|%s|[%s]|%s", lvl, unixTime, location, r.Msg)
 			}
 		} else {
 			if color > 0 {
-				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m|%s|%s|%s", color, lvl, r.Time.Format(nanoTermTimeFormat), unixTime, r.Msg)
+				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m|%s|%s", color, lvl, unixTime, r.Msg)
 			} else {
-				fmt.Fprintf(b, "%s|%s|%s|%s", lvl, r.Time.Format(nanoTermTimeFormat), unixTime, r.Msg)
+				fmt.Fprintf(b, "%s|%s|%s", lvl, unixTime, r.Msg)
 			}
 		}
 		// print the keys logfmt style

--- a/log/handler.go
+++ b/log/handler.go
@@ -193,6 +193,19 @@ func LvlFilterHandler(maxLvl Lvl, h Handler) Handler {
 	}, h)
 }
 
+// LvlMatchFilterFileHandler returns a Handler that only writes
+// records which are equal to the given verbosity
+// level to a FileHandler. For example, to only
+// log Error records to datadir/eror.log:
+//
+//     log.LvlMatchFilterFileHandler(log.LvlError, datadir)
+//
+func LvlMatchFilterFileHandler(targetLvl Lvl, logDir string) Handler {
+	return FilterHandler(func(r *Record) (pass bool) {
+		return r.Lvl == targetLvl
+	}, Must.FileHandler(fmt.Sprintf("%s/%s.log", logDir, targetLvl.String()), TerminalFormat(false)))
+}
+
 // A MultiHandler dispatches any write to each of its handlers.
 // This is useful for writing different types of log information
 // to different locations. For example, to log to a file and

--- a/log/handler_glog.go
+++ b/log/handler_glog.go
@@ -57,6 +57,12 @@ func NewGlogHandler(h Handler) *GlogHandler {
 	}
 }
 
+func (h *GlogHandler) SetHandler(newh Handler) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.origin = newh
+}
+
 // pattern contains a filter for the Vmodule option, holding a verbosity level
 // and a file pattern to match.
 type pattern struct {

--- a/log/root.go
+++ b/log/root.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	root          = &logger{[]interface{}{}, new(swapHandler)}
+	root          = &logger{ctx: []interface{}{}, h: new(swapHandler)}
 	StdoutHandler = StreamHandler(os.Stdout, LogfmtFormat())
 	StderrHandler = StreamHandler(os.Stderr, LogfmtFormat())
 )
@@ -28,6 +28,11 @@ func Root() Logger {
 // The following functions bypass the exported logger methods (logger.Debug,
 // etc.) to keep the call depth the same for all paths to logger.write so
 // runtime.Caller(2) always refers to the call site in client code.
+
+// Type is a convenient alias for Root().Type
+func Type(msg string, ctx ...interface{}) {
+	root.write(msg, LvlType, ctx)
+}
 
 // Trace is a convenient alias for Root().Trace
 func Trace(msg string, ctx ...interface{}) {
@@ -58,4 +63,34 @@ func Error(msg string, ctx ...interface{}) {
 func Crit(msg string, ctx ...interface{}) {
 	root.write(msg, LvlCrit, ctx)
 	os.Exit(1)
+}
+
+// Neighbors is a convenient alias for Root().Neighbors
+func Neighbors(msg string, ctx ...interface{}) {
+	root.write(msg, LvlNeighbors, ctx)
+}
+
+// Hello is a convenient alias for Root().Hello
+func Hello(msg string, ctx ...interface{}) {
+	root.write(msg, LvlHello, ctx)
+}
+
+// DiscProto is a convenient alias for Root().DiscProto
+func DiscProto(msg string, ctx ...interface{}) {
+	root.write(msg, LvlDiscProto, ctx)
+}
+
+// DiscPeer is a convenient alias for Root().DiscPeer
+func DiscPeer(msg string, ctx ...interface{}) {
+	root.write(msg, LvlDiscPeer, ctx)
+}
+
+// Status is a convenient alias for Root().Status
+func Status(msg string, ctx ...interface{}) {
+	root.write(msg, LvlStatus, ctx)
+}
+
+// DaoFork is a convenient alias for Root().DaoFork
+func DaoFork(msg string, ctx ...interface{}) {
+	root.write(msg, LvlDaoFork, ctx)
 }

--- a/node/config.go
+++ b/node/config.go
@@ -47,6 +47,8 @@ const (
 // P2P network layer of a protocol stack. These values can be further extended by
 // all registered services.
 type Config struct {
+	LogToFile bool `toml:",omitempty"`
+
 	// Name sets the instance name of the node. It must not contain the / character and is
 	// used in the devp2p node identifier. The instance name of geth is "geth". If no
 	// value is specified, the basename of the current executable is used.

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -45,13 +45,13 @@ var DefaultConfig = Config{
 		DiscoveryV5Addr: ":30304",
 		MaxPeers:        25,
 		NAT:             nat.Any(),
+		MaxDial:         16,
+		NoMaxPeers:      false,
+		MaxAcceptConns:  50,
+		DialFreq:        30,
 		MySQLName:       "",
 		BackupSQL:       false,
 		ResetSQL:        false,
-		MaxDial:         16,
-		MaxAcceptConns:  50,
-		DialFreq:        30,
-		NoMaxPeers:      false,
 	},
 }
 

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -140,12 +140,20 @@ func newDialState(static []*discover.Node, ntab discoverTable, maxdyn int, netre
 	return s
 }
 
-func (s *dialstate) setBlacklist(blacklist *netutil.Netlist) {
-	s.blacklist = blacklist
+func (s *dialstate) GetDialFreq() time.Duration {
+	return s.dialFreq
 }
 
-func (s *dialstate) setDialFreq(f int) {
+func (s *dialstate) SetDialFreq(f int) {
 	s.dialFreq = time.Duration(f) * time.Second
+}
+
+func (s *dialstate) GetBlacklist() *netutil.Netlist {
+	return s.blacklist
+}
+
+func (s *dialstate) SetBlacklist(blacklist *netutil.Netlist) {
+	s.blacklist = blacklist
 }
 
 func (s *dialstate) addStatic(n *discover.Node) {

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -97,7 +97,7 @@ func (t fakeTable) ReadRandomNodes(buf []*discover.Node) int { return copy(buf, 
 // This test checks that dynamic dials are launched from discovery results.
 func TestDialStateDynDial(t *testing.T) {
 	dialer := newDialState(nil, fakeTable{}, 5, nil)
-	dialer.setDialFreq(30)
+	dialer.SetDialFreq(30)
 	runDialTest(t, dialtest{
 		init: dialer,
 		rounds: []round{
@@ -246,7 +246,7 @@ func TestDialStateDynDialFromTable(t *testing.T) {
 	}
 
 	dialer := newDialState(nil, table, 10, nil)
-	dialer.setDialFreq(30)
+	dialer.SetDialFreq(30)
 	runDialTest(t, dialtest{
 		init: dialer,
 		rounds: []round{
@@ -346,7 +346,7 @@ func TestDialStateNetRestrict(t *testing.T) {
 	restrict.Add("127.0.2.0/24")
 
 	dialer := newDialState(nil, table, 10, restrict)
-	dialer.setDialFreq(30)
+	dialer.SetDialFreq(30)
 	runDialTest(t, dialtest{
 		init: dialer,
 		rounds: []round{
@@ -371,7 +371,7 @@ func TestDialStateStaticDial(t *testing.T) {
 	}
 
 	dialer := newDialState(wantStatic, fakeTable{}, 0, nil)
-	dialer.setDialFreq(30)
+	dialer.SetDialFreq(30)
 	runDialTest(t, dialtest{
 		init: dialer,
 		rounds: []round{
@@ -454,7 +454,7 @@ func TestDialStateCache(t *testing.T) {
 	}
 
 	dialer := newDialState(wantStatic, fakeTable{}, 0, nil)
-	dialer.setDialFreq(30)
+	dialer.SetDialFreq(30)
 	runDialTest(t, dialtest{
 		init: dialer,
 		rounds: []round{
@@ -519,7 +519,7 @@ func TestDialResolve(t *testing.T) {
 	resolved := discover.NewNode(uintID(1), net.IP{127, 0, 55, 234}, 3333, 4444)
 	table := &resolveMock{answer: resolved}
 	state := newDialState(nil, table, 0, nil)
-	state.setDialFreq(30)
+	state.SetDialFreq(30)
 
 	// Check that the task is generated with an incomplete ID.
 	dest := discover.NewNode(uintID(1), nil, 0, 0)

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -40,10 +40,12 @@ import (
 // structure, encode the payload into a byte array and create a
 // separate Msg with a bytes.Reader as Payload for each send.
 type Msg struct {
-	Code       uint64
-	Size       uint32 // size of the paylod
-	Payload    io.Reader
-	ReceivedAt time.Time
+	Code         uint64
+	Size         uint32 // size of the paylod
+	Payload      io.Reader
+	ReceivedAt   time.Time
+	PeerRtt      float64
+	PeerDuration float64
 }
 
 // Decode parses the RLP content of a message into

--- a/p2p/netutil/net.go
+++ b/p2p/netutil/net.go
@@ -81,7 +81,16 @@ func ParseNetlist(s string) (*Netlist, error) {
 		}
 		l = append(l, *n)
 	}
-	return &l, nil
+	result := make(Netlist, 0)
+	seen := map[string]*net.IPNet{}
+	for _, val := range l {
+		cidr := val.String()
+		if _, ok := seen[cidr]; !ok {
+			result = append(result, val)
+			seen[cidr] = &val
+		}
+	}
+	return &result, nil
 }
 
 // MarshalTOML implements toml.MarshalerRec.
@@ -117,6 +126,15 @@ func (l *Netlist) Add(cidr string) {
 		panic(err)
 	}
 	*l = append(*l, *n)
+}
+
+func (l *Netlist) AddNonDuplicate(cidr string) {
+	for _, val := range *l {
+		if cidr == val.String() {
+			return
+		}
+	}
+	l.Add(cidr)
 }
 
 // Contains reports whether the given IP is contained in the list.

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -255,9 +255,9 @@ func (srv *Server) getNodeAddress(c *conn, receivedAt *time.Time) (*Info, bool, 
 	return newNodeInfo, dial, accept
 }
 
-func (srv *Server) storeNodeInfo(c *conn, receivedAt *time.Time, hs *protoHandshake) {
+func (srv *Server) storeNodeP2PInfo(c *conn, msg *Msg, hs *protoHandshake) {
 	// node address currentInfo
-	newInfo, dial, accept := srv.getNodeAddress(c, receivedAt)
+	newInfo, dial, accept := srv.getNodeAddress(c, &msg.ReceivedAt)
 	id := hs.ID
 	nodeid := id.String()
 	if srv.DB != nil {
@@ -317,7 +317,9 @@ func (srv *Server) storeNodeInfo(c *conn, receivedAt *time.Time, hs *protoHandsh
 	if srv.DB != nil {
 		srv.addNodeP2PInfo(&KnownNodeInfosWrapper{nodeid, newInfo})
 	}
-	log.Info("[HELLO]", "receivedAt", newInfo.LastHelloAt, "id", nodeid, "addr", c.fd.RemoteAddr().String(), "conn", c.flags, "info", newInfo.P2PSummary())
+	log.Hello(fmt.Sprintf("%f", newInfo.LastHelloAt.Float64()),
+		"id", nodeid, "addr", c.fd.RemoteAddr(), "conn", c.flags, "rtt", msg.PeerRtt,
+		"info", newInfo.P2PSummary())
 }
 
 func isNewNode(oldInfo *Info, newInfo *Info) bool {

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -32,6 +32,7 @@ import (
 	"io/ioutil"
 	mrand "math/rand"
 	"net"
+	"runtime"
 	"sync"
 	"time"
 
@@ -55,7 +56,7 @@ const (
 	authMsgLen  = sigLen + shaLen + pubLen + shaLen + 1
 	authRespLen = pubLen + shaLen + 1
 
-	eciesOverhead = 65 + 16 + 32 /* pubkey + IV + MAC */
+	eciesOverhead = 65 /* pubkey */ + 16 /* IV */ + 32 /* MAC */
 
 	encAuthMsgLen  = authMsgLen + eciesOverhead  // size of encrypted pre-EIP-8 initiator handshake
 	encAuthRespLen = authRespLen + eciesOverhead // size of encrypted pre-EIP-8 handshake reply
@@ -86,6 +87,10 @@ type rlpx struct {
 func newRLPX(fd net.Conn) transport {
 	fd.SetDeadline(time.Now().Add(handshakeTimeout))
 	return &rlpx{fd: fd}
+}
+
+func (t *rlpx) Rtt() float64 {
+	return t.rw.rtt
 }
 
 func (t *rlpx) ReadMsg() (Msg, error) {
@@ -119,34 +124,33 @@ func (t *rlpx) close(err error) {
 // messages. the protocol handshake is the first authenticated message
 // and also verifies whether the encryption handshake 'worked' and the
 // remote side actually provided the right public key.
-func (t *rlpx) doProtoHandshake(our *protoHandshake) (their *protoHandshake, receivedAt *time.Time, err error) {
+func (t *rlpx) doProtoHandshake(our *protoHandshake) (their *protoHandshake, msg Msg, err error) {
 	// Writing our handshake happens concurrently, we prefer
 	// returning the handshake read error. If the remote side
 	// disconnects us early with a valid reason, we should return it
 	// as the error so it can be tracked elsewhere.
 	werr := make(chan error, 1)
 	go func() { werr <- Send(t.rw, handshakeMsg, our) }()
-	if their, receivedAt, err = readProtocolHandshake(t.rw, our); err != nil {
+	if their, msg, err = readProtocolHandshake(t.rw, our); err != nil {
 		<-werr // make sure the write terminates too
-		return nil, receivedAt, err
+		return nil, msg, err
 	}
 	if err := <-werr; err != nil {
-		return nil, receivedAt, fmt.Errorf("write error: %v", err)
+		return nil, msg, fmt.Errorf("write error: %v", err)
 	}
 	// If the protocol version supports Snappy encoding, upgrade immediately
 	t.rw.snappy = their.Version >= snappyProtocolVersion
 
-	return their, receivedAt, nil
+	return their, msg, nil
 }
 
-func readProtocolHandshake(rw MsgReader, our *protoHandshake) (*protoHandshake, *time.Time, error) {
+func readProtocolHandshake(rw MsgReader, our *protoHandshake) (*protoHandshake, Msg, error) {
 	msg, err := rw.ReadMsg()
 	if err != nil {
-		return nil, nil, err
+		return nil, msg, err
 	}
-	msg.ReceivedAt = time.Now()
 	if msg.Size > baseProtocolMaxMsgSize {
-		return nil, &msg.ReceivedAt, fmt.Errorf("message too big")
+		return nil, msg, fmt.Errorf("message too big")
 	}
 	if msg.Code == discMsg {
 		// Disconnect before protocol handshake is valid according to the
@@ -155,19 +159,19 @@ func readProtocolHandshake(rw MsgReader, our *protoHandshake) (*protoHandshake, 
 		// back otherwise. Wrap it in a string instead.
 		var reason [1]DiscReason
 		rlp.Decode(msg.Payload, &reason)
-		return nil, &msg.ReceivedAt, reason[0]
+		return nil, msg, reason[0]
 	}
 	if msg.Code != handshakeMsg {
-		return nil, &msg.ReceivedAt, fmt.Errorf("expected handshake, got %x", msg.Code)
+		return nil, msg, fmt.Errorf("expected handshake, got %x", msg.Code)
 	}
 	var hs protoHandshake
 	if err := msg.Decode(&hs); err != nil {
-		return nil, &msg.ReceivedAt, err
+		return nil, msg, err
 	}
 	if (hs.ID == discover.NodeID{}) {
-		return nil, &msg.ReceivedAt, DiscInvalidIdentity
+		return nil, msg, DiscInvalidIdentity
 	}
-	return &hs, &msg.ReceivedAt, nil
+	return &hs, msg, nil
 }
 
 func (t *rlpx) doEncHandshake(prv *ecdsa.PrivateKey, dial *discover.Node) (discover.NodeID, error) {
@@ -567,6 +571,8 @@ type rlpxFrameRW struct {
 	egressMAC  hash.Hash
 	ingressMAC hash.Hash
 
+	rtt float64 // most recent rtt recorded when receiving messages
+
 	snappy bool
 }
 
@@ -691,6 +697,12 @@ func (rw *rlpxFrameRW) ReadMsg() (msg Msg, err error) {
 	}
 	msg.Size = uint32(content.Len())
 	msg.Payload = content
+
+	msg.ReceivedAt = time.Now()
+	// get the most recent rtt and duration of the peer
+	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+		msg.PeerRtt = rw.Rtt()
+	}
 
 	// if snappy is enabled, verify and decompress message
 	if rw.snappy {

--- a/p2p/rlpx_test.go
+++ b/p2p/rlpx_test.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -143,6 +144,79 @@ func testEncHandshake(token []byte) error {
 		return fmt.Errorf("dec cipher mismatch:\n c0.rw: %#v\n c1.rw: %#v", c0.rw.dec, c1.rw.dec)
 	}
 	return nil
+}
+
+func TestProtocolHandshake(t *testing.T) {
+	var (
+		prv0, _ = crypto.GenerateKey()
+		node0   = &discover.Node{ID: discover.PubkeyID(&prv0.PublicKey), IP: net.IP{1, 2, 3, 4}, TCP: 33}
+		hs0     = &protoHandshake{Version: 3, ID: node0.ID, Caps: []Cap{{"a", 0}, {"b", 2}}}
+
+		prv1, _ = crypto.GenerateKey()
+		node1   = &discover.Node{ID: discover.PubkeyID(&prv1.PublicKey), IP: net.IP{5, 6, 7, 8}, TCP: 44}
+		hs1     = &protoHandshake{Version: 3, ID: node1.ID, Caps: []Cap{{"c", 1}, {"d", 3}}}
+
+		fd0, fd1 = net.Pipe()
+		wg       sync.WaitGroup
+	)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		defer fd1.Close()
+		rlpx := newRLPX(fd0)
+		remid, err := rlpx.doEncHandshake(prv0, node1)
+		if err != nil {
+			t.Errorf("dial side enc handshake failed: %v", err)
+			return
+		}
+		if remid != node1.ID {
+			t.Errorf("dial side remote id mismatch: got %v, want %v", remid, node1.ID)
+			return
+		}
+
+		phs, _, err := rlpx.doProtoHandshake(hs0)
+		if err != nil {
+			t.Errorf("dial side proto handshake error: %v", err)
+			return
+		}
+		phs.Rest = nil
+		if !reflect.DeepEqual(phs, hs1) {
+			t.Errorf("dial side proto handshake mismatch:\ngot: %s\nwant: %s\n", spew.Sdump(phs), spew.Sdump(hs1))
+			return
+		}
+		rlpx.close(DiscQuitting)
+	}()
+	go func() {
+		defer wg.Done()
+		defer fd1.Close()
+		rlpx := newRLPX(fd1)
+		remid, err := rlpx.doEncHandshake(prv1, nil)
+		if err != nil {
+			t.Errorf("listen side enc handshake failed: %v", err)
+			return
+		}
+		if remid != node0.ID {
+			t.Errorf("listen side remote id mismatch: got %v, want %v", remid, node0.ID)
+			return
+		}
+
+		phs, _, err := rlpx.doProtoHandshake(hs1)
+		if err != nil {
+			t.Errorf("listen side proto handshake error: %v", err)
+			return
+		}
+		phs.Rest = nil
+		if !reflect.DeepEqual(phs, hs0) {
+			t.Errorf("listen side proto handshake mismatch:\ngot: %s\nwant: %s\n", spew.Sdump(phs), spew.Sdump(hs0))
+			return
+		}
+
+		if err := ExpectMsg(rlpx, discMsg, []DiscReason{DiscQuitting}); err != nil {
+			t.Errorf("error receiving disconnect: %v", err)
+		}
+	}()
+	wg.Wait()
 }
 
 func TestProtocolHandshakeErrors(t *testing.T) {

--- a/p2p/rtt_darwin.go
+++ b/p2p/rtt_darwin.go
@@ -1,0 +1,41 @@
+// +build darwin
+
+package p2p
+
+import (
+	"net"
+	"syscall"
+	"unsafe"
+
+	"github.com/teamnsrg/go-ethereum/tcpinfo"
+)
+
+// Srtt in seconds (originally milliseconds)
+func (rw *rlpxFrameRW) Rtt() float64 {
+	tcpInfo := rw.GetTCPInfo()
+	if tcpInfo == nil {
+		return rw.rtt
+	}
+	rw.rtt = float64(tcpInfo.Srtt) / 1000
+	return rw.rtt
+}
+
+func (rw *rlpxFrameRW) GetTCPInfo() *tcpinfo.TCPConnectionInfo {
+	tcpConn, ok := rw.conn.(*net.TCPConn)
+	if !ok {
+		return nil
+	}
+	file, err := tcpConn.File()
+	if err != nil {
+		return nil
+	}
+	fd := file.Fd()
+	size := tcpinfo.SizeofTCPConnectionInfo
+	tcpInfo := tcpinfo.TCPConnectionInfo{}
+	_, _, e1 := syscall.Syscall6(syscall.SYS_GETSOCKOPT, uintptr(int(fd)), uintptr(syscall.IPPROTO_TCP),
+		uintptr(tcpinfo.TCP_CONNECTION_INFO), uintptr(unsafe.Pointer(&tcpInfo)), uintptr(unsafe.Pointer(&size)), 0)
+	if e1 != 0 {
+		return nil
+	}
+	return &tcpInfo
+}

--- a/p2p/rtt_linux.go
+++ b/p2p/rtt_linux.go
@@ -1,0 +1,41 @@
+// +build linux
+
+package p2p
+
+import (
+	"net"
+	"syscall"
+	"unsafe"
+
+	"github.com/teamnsrg/go-ethereum/tcpinfo"
+)
+
+// Srtt in seconds (originally microseconds)
+func (rw *rlpxFrameRW) Rtt() float64 {
+	tcpInfo := rw.GetTCPInfo()
+	if tcpInfo == nil {
+		return rw.rtt
+	}
+	rw.rtt = float64(tcpInfo.Rtt) / 1000000
+	return rw.rtt
+}
+
+func (rw *rlpxFrameRW) GetTCPInfo() *tcpinfo.TCPInfo {
+	tcpConn, ok := rw.conn.(*net.TCPConn)
+	if !ok {
+		return nil
+	}
+	file, err := tcpConn.File()
+	if err != nil {
+		return nil
+	}
+	fd := file.Fd()
+	size := tcpinfo.SizeofTCPInfo
+	tcpInfo := tcpinfo.TCPInfo{}
+	_, _, e1 := syscall.Syscall6(syscall.SYS_GETSOCKOPT, uintptr(int(fd)), uintptr(syscall.SOL_TCP),
+		uintptr(tcpinfo.TCP_INFO), uintptr(unsafe.Pointer(&tcpInfo)), uintptr(unsafe.Pointer(&size)), 0)
+	if e1 != 0 {
+		return nil
+	}
+	return &tcpInfo
+}

--- a/tcpinfo/LICENSE
+++ b/tcpinfo/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2016, Mikio Hara
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tcpinfo/defs_darwin.go
+++ b/tcpinfo/defs_darwin.go
@@ -1,0 +1,19 @@
+// Copyright 2016 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build ignore
+
+package tcpinfo
+
+/*
+#include <netinet/tcp.h>
+*/
+import "C"
+
+const (
+	TCP_CONNECTION_INFO     = C.TCP_CONNECTION_INFO
+	SizeofTCPConnectionInfo = C.sizeof_struct_tcp_connection_info
+)
+
+type TCPConnectionInfo C.struct_tcp_connection_info

--- a/tcpinfo/defs_freebsd.go
+++ b/tcpinfo/defs_freebsd.go
@@ -1,0 +1,26 @@
+// Copyright 2016 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build ignore
+
+package tcpinfo
+
+/*
+#include <netinet/tcp.h>
+*/
+import "C"
+
+const (
+	sysTCP_INFO = C.TCP_INFO
+
+	sysTCPI_OPT_TIMESTAMPS = C.TCPI_OPT_TIMESTAMPS
+	sysTCPI_OPT_SACK       = C.TCPI_OPT_SACK
+	sysTCPI_OPT_WSCALE     = C.TCPI_OPT_WSCALE
+	sysTCPI_OPT_ECN        = C.TCPI_OPT_ECN
+	sysTCPI_OPT_TOE        = C.TCPI_OPT_TOE
+
+	sizeofTCPInfo = C.sizeof_struct_tcp_info
+)
+
+type tcpInfo C.struct_tcp_info

--- a/tcpinfo/defs_linux.go
+++ b/tcpinfo/defs_linux.go
@@ -1,0 +1,19 @@
+// Copyright 2016 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build ignore
+
+package tcpinfo
+
+/*
+#include <linux/tcp.h>
+*/
+import "C"
+
+const (
+	TCP_INFO      = C.TCP_INFO
+	SizeofTCPInfo = C.sizeof_struct_tcp_info
+)
+
+type TCPInfo C.struct_tcp_info

--- a/tcpinfo/defs_netbsd.go
+++ b/tcpinfo/defs_netbsd.go
@@ -1,0 +1,26 @@
+// Copyright 2016 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build ignore
+
+package tcpinfo
+
+/*
+#include <netinet/tcp.h>
+*/
+import "C"
+
+const (
+	sysTCP_INFO = C.TCP_INFO
+
+	sysTCPI_OPT_TIMESTAMPS = C.TCPI_OPT_TIMESTAMPS
+	sysTCPI_OPT_SACK       = C.TCPI_OPT_SACK
+	sysTCPI_OPT_WSCALE     = C.TCPI_OPT_WSCALE
+	sysTCPI_OPT_ECN        = C.TCPI_OPT_ECN
+	sysTCPI_OPT_TOE        = C.TCPI_OPT_TOE
+
+	sizeofTCPInfo = C.sizeof_struct_tcp_info
+)
+
+type tcpInfo C.struct_tcp_info

--- a/tcpinfo/doc.go
+++ b/tcpinfo/doc.go
@@ -1,0 +1,46 @@
+// Copyright 2016 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package tcpinfo implements encoding and decoding of TCP-level
+// socket options regarding connection information.
+//
+// The Transmission Control Protocol (TCP) is defined in RFC 793.
+// TCP Selective Acknowledgment Options is defined in RFC 2018.
+// Management Information Base for the Transmission Control Protocol
+// (TCP) is defined in RFC 4022.
+// TCP Congestion Control is defined in RFC 5681.
+// Computing TCP's Retransmission Timer is described in RFC 6298.
+// TCP Options and Maximum Segment Size (MSS) is defined in RFC 6691.
+// Shared Use of Experimental TCP Options is defined in RFC 6994.
+// TCP Extensions for High Performance is defined in RFC 7323.
+//
+// Example:
+//
+//	import (
+//		"github.com/mikioh/tcp"
+//		"github.com/mikioh/tcpinfo"
+//	)
+//
+//	c, err := net.Dial("tcp", "golang.org:80")
+//	if err != nil {
+//		// error handling
+//	}
+//	defer c.Close()
+//
+//	tc, err := tcp.NewConn(c)
+//	if err != nil {
+//		// error handling
+//	}
+//	var o tcpinfo.Info
+//	var b [256]byte
+//	i, err := tc.Option(o.Level(), o.Name(), b[:])
+//	if err != nil {
+//		// error handling
+//	}
+//	txt, err := json.Marshal(i)
+//	if err != nil {
+//		// error handling
+//	}
+//	fmt.Println(txt)
+package tcpinfo

--- a/tcpinfo/zsys_darwin.go
+++ b/tcpinfo/zsys_darwin.go
@@ -1,0 +1,36 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs tcpinfo/defs_darwin.go
+
+package tcpinfo
+
+const (
+	TCP_CONNECTION_INFO     = 0x106
+	SizeofTCPConnectionInfo = 0x70
+)
+
+type TCPConnectionInfo struct {
+	State               uint8
+	Snd_wscale          uint8
+	Rcv_wscale          uint8
+	X__pad1             uint8
+	Options             uint32
+	Flags               uint32
+	Rto                 uint32
+	Maxseg              uint32
+	Snd_ssthresh        uint32
+	Snd_cwnd            uint32
+	Snd_wnd             uint32
+	Snd_sbbytes         uint32
+	Rcv_wnd             uint32
+	Rttcur              uint32
+	Srtt                uint32
+	Rttvar              uint32
+	Pad_cgo_0           [4]byte
+	Txpackets           uint64
+	Txbytes             uint64
+	Txretransmitbytes   uint64
+	Rxpackets           uint64
+	Rxbytes             uint64
+	Rxoutoforderbytes   uint64
+	Txretransmitpackets uint64
+}

--- a/tcpinfo/zsys_freebsd.go
+++ b/tcpinfo/zsys_freebsd.go
@@ -1,0 +1,58 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs defs_freebsd.go
+
+package tcpinfo
+
+const (
+	sysTCP_INFO = 0x20
+
+	sysTCPI_OPT_TIMESTAMPS = 0x1
+	sysTCPI_OPT_SACK       = 0x2
+	sysTCPI_OPT_WSCALE     = 0x4
+	sysTCPI_OPT_ECN        = 0x8
+	sysTCPI_OPT_TOE        = 0x10
+
+	sizeofTCPInfo = 0xec
+)
+
+type tcpInfo struct {
+	State                  uint8
+	X__tcpi_ca_state       uint8
+	X__tcpi_retransmits    uint8
+	X__tcpi_probes         uint8
+	X__tcpi_backoff        uint8
+	Options                uint8
+	Pad_cgo_0              [2]byte
+	Rto                    uint32
+	X__tcpi_ato            uint32
+	Snd_mss                uint32
+	Rcv_mss                uint32
+	X__tcpi_unacked        uint32
+	X__tcpi_sacked         uint32
+	X__tcpi_lost           uint32
+	X__tcpi_retrans        uint32
+	X__tcpi_fackets        uint32
+	X__tcpi_last_data_sent uint32
+	X__tcpi_last_ack_sent  uint32
+	Last_data_recv         uint32
+	X__tcpi_last_ack_recv  uint32
+	X__tcpi_pmtu           uint32
+	X__tcpi_rcv_ssthresh   uint32
+	Rtt                    uint32
+	Rttvar                 uint32
+	Snd_ssthresh           uint32
+	Snd_cwnd               uint32
+	X__tcpi_advmss         uint32
+	X__tcpi_reordering     uint32
+	X__tcpi_rcv_rtt        uint32
+	Rcv_space              uint32
+	Snd_wnd                uint32
+	Snd_bwnd               uint32
+	Snd_nxt                uint32
+	Rcv_nxt                uint32
+	Toe_tid                uint32
+	Snd_rexmitpack         uint32
+	Rcv_ooopack            uint32
+	Snd_zerowin            uint32
+	X__tcpi_pad            [26]uint32
+}

--- a/tcpinfo/zsys_linux.go
+++ b/tcpinfo/zsys_linux.go
@@ -1,0 +1,49 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs tcpinfo/defs_linux.go
+
+package tcpinfo
+
+const (
+	TCP_INFO      = 0xb
+	SizeofTCPInfo = 0x90
+)
+
+type TCPInfo struct {
+	State           uint8
+	Ca_state        uint8
+	Retransmits     uint8
+	Probes          uint8
+	Backoff         uint8
+	Options         uint8
+	Pad_cgo_0       [2]byte
+	Rto             uint32
+	Ato             uint32
+	Snd_mss         uint32
+	Rcv_mss         uint32
+	Unacked         uint32
+	Sacked          uint32
+	Lost            uint32
+	Retrans         uint32
+	Fackets         uint32
+	Last_data_sent  uint32
+	Last_ack_sent   uint32
+	Last_data_recv  uint32
+	Last_ack_recv   uint32
+	Pmtu            uint32
+	Rcv_ssthresh    uint32
+	Rtt             uint32
+	Rttvar          uint32
+	Snd_ssthresh    uint32
+	Snd_cwnd        uint32
+	Advmss          uint32
+	Reordering      uint32
+	Rcv_rtt         uint32
+	Rcv_space       uint32
+	Total_retrans   uint32
+	Pacing_rate     uint64
+	Max_pacing_rate uint64
+	Bytes_acked     uint64
+	Bytes_received  uint64
+	Segs_out        uint32
+	Segs_in         uint32
+}

--- a/tcpinfo/zsys_netbsd.go
+++ b/tcpinfo/zsys_netbsd.go
@@ -1,0 +1,58 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs defs_netbsd.go
+
+package tcpinfo
+
+const (
+	sysTCP_INFO = 0x9
+
+	sysTCPI_OPT_TIMESTAMPS = 0x1
+	sysTCPI_OPT_SACK       = 0x2
+	sysTCPI_OPT_WSCALE     = 0x4
+	sysTCPI_OPT_ECN        = 0x8
+	sysTCPI_OPT_TOE        = 0x10
+
+	sizeofTCPInfo = 0xec
+)
+
+type tcpInfo struct {
+	State                  uint8
+	X__tcpi_ca_state       uint8
+	X__tcpi_retransmits    uint8
+	X__tcpi_probes         uint8
+	X__tcpi_backoff        uint8
+	Options                uint8
+	Pad_cgo_0              [2]byte
+	Rto                    uint32
+	X__tcpi_ato            uint32
+	Snd_mss                uint32
+	Rcv_mss                uint32
+	X__tcpi_unacked        uint32
+	X__tcpi_sacked         uint32
+	X__tcpi_lost           uint32
+	X__tcpi_retrans        uint32
+	X__tcpi_fackets        uint32
+	X__tcpi_last_data_sent uint32
+	X__tcpi_last_ack_sent  uint32
+	Last_data_recv         uint32
+	X__tcpi_last_ack_recv  uint32
+	X__tcpi_pmtu           uint32
+	X__tcpi_rcv_ssthresh   uint32
+	Rtt                    uint32
+	Rttvar                 uint32
+	Snd_ssthresh           uint32
+	Snd_cwnd               uint32
+	X__tcpi_advmss         uint32
+	X__tcpi_reordering     uint32
+	X__tcpi_rcv_rtt        uint32
+	Rcv_space              uint32
+	Snd_wnd                uint32
+	Snd_bwnd               uint32
+	Snd_nxt                uint32
+	Rcv_nxt                uint32
+	Toe_tid                uint32
+	Snd_rexmitpack         uint32
+	Rcv_ooopack            uint32
+	Snd_zerowin            uint32
+	X__tcpi_pad            [26]uint32
+}

--- a/vendor/github.com/go-sql-driver/mysql/AUTHORS
+++ b/vendor/github.com/go-sql-driver/mysql/AUTHORS
@@ -13,6 +13,8 @@
 
 Aaron Hopkins <go-sql-driver at die.net>
 Achille Roussel <achille.roussel at gmail.com>
+Alexey Palazhchenko <alexey.palazhchenko at gmail.com>
+Andrew Reid <andrew.reid at tixtrack.com>
 Arne Hormann <arnehormann at gmail.com>
 Asta Xie <xiemengjun at gmail.com>
 Bulat Gaifullin <gaifullinbf at gmail.com>
@@ -61,8 +63,8 @@ Paul Bonser <misterpib at gmail.com>
 Peter Schultz <peter.schultz at classmarkets.com>
 Rebecca Chin <rchin at pivotal.io>
 Reed Allman <rdallman10 at gmail.com>
-Runrioter Wung <runrioter at gmail.com>
 Robert Russell <robert at rrbrussell.com>
+Runrioter Wung <runrioter at gmail.com>
 Shuode Li <elemount at qq.com>
 Soroush Pour <me at soroushjp.com>
 Stan Putrya <root.vagner at gmail.com>
@@ -79,5 +81,6 @@ Counting Ltd.
 Google Inc.
 InfoSum Ltd.
 Keybase Inc.
+Percona LLC
 Pivotal Inc.
 Stripe Inc.

--- a/vendor/github.com/go-sql-driver/mysql/statement.go
+++ b/vendor/github.com/go-sql-driver/mysql/statement.go
@@ -132,15 +132,25 @@ func (stmt *mysqlStmt) query(args []driver.Value) (*binaryRows, error) {
 
 type converter struct{}
 
+// ConvertValue mirrors the reference/default converter in database/sql/driver
+// with _one_ exception.  We support uint64 with their high bit and the default
+// implementation does not.  This function should be kept in sync with
+// database/sql/driver defaultConverter.ConvertValue() except for that
+// deliberate difference.
 func (c converter) ConvertValue(v interface{}) (driver.Value, error) {
 	if driver.IsValue(v) {
 		return v, nil
 	}
 
-	if v != nil {
-		if valuer, ok := v.(driver.Valuer); ok {
-			return valuer.Value()
+	if vr, ok := v.(driver.Valuer); ok {
+		sv, err := callValuerValue(vr)
+		if err != nil {
+			return nil, err
 		}
+		if !driver.IsValue(sv) {
+			return nil, fmt.Errorf("non-Value type %T returned from Value", sv)
+		}
+		return sv, nil
 	}
 
 	rv := reflect.ValueOf(v)
@@ -149,8 +159,9 @@ func (c converter) ConvertValue(v interface{}) (driver.Value, error) {
 		// indirect pointers
 		if rv.IsNil() {
 			return nil, nil
+		} else {
+			return c.ConvertValue(rv.Elem().Interface())
 		}
-		return c.ConvertValue(rv.Elem().Interface())
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return rv.Int(), nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32:
@@ -175,4 +186,26 @@ func (c converter) ConvertValue(v interface{}) (driver.Value, error) {
 		return rv.String(), nil
 	}
 	return nil, fmt.Errorf("unsupported type %T, a %s", v, rv.Kind())
+}
+
+var valuerReflectType = reflect.TypeOf((*driver.Valuer)(nil)).Elem()
+
+// callValuerValue returns vr.Value(), with one exception:
+// If vr.Value is an auto-generated method on a pointer type and the
+// pointer is nil, it would panic at runtime in the panicwrap
+// method. Treat it like nil instead.
+//
+// This is so people can implement driver.Value on value types and
+// still use nil pointers to those types to mean nil/NULL, just like
+// string/*string.
+//
+// This is an exact copy of the same-named unexported function from the
+// database/sql package.
+func callValuerValue(vr driver.Valuer) (v driver.Value, err error) {
+	if rv := reflect.ValueOf(vr); rv.Kind() == reflect.Ptr &&
+		rv.IsNil() &&
+		rv.Type().Elem().Implements(valuerReflectType) {
+		return nil, nil
+	}
+	return vr.Value()
 }

--- a/vendor/github.com/go-sql-driver/mysql/utils.go
+++ b/vendor/github.com/go-sql-driver/mysql/utils.go
@@ -537,7 +537,7 @@ func readLengthEncodedString(b []byte) ([]byte, bool, int, error) {
 
 	// Check data length
 	if len(b) >= n {
-		return b[n-int(num) : n], false, n, nil
+		return b[n-int(num) : n : n], false, n, nil
 	}
 	return nil, false, n, io.EOF
 }
@@ -800,7 +800,7 @@ func (ab *atomicBool) TrySet(value bool) bool {
 	return atomic.SwapUint32(&ab.value, 0) > 0
 }
 
-// atomicBool is a wrapper for atomically accessed error values
+// atomicError is a wrapper for atomically accessed error values
 type atomicError struct {
 	_noCopy noCopy
 	value   atomic.Value

--- a/vendor/github.com/go-sql-driver/mysql/utils_go18.go
+++ b/vendor/github.com/go-sql-driver/mysql/utils_go18.go
@@ -15,6 +15,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 )
 
 func cloneTLSConfig(c *tls.Config) *tls.Config {
@@ -44,6 +45,6 @@ func mapIsolationLevel(level driver.IsolationLevel) (string, error) {
 	case sql.LevelSerializable:
 		return "SERIALIZABLE", nil
 	default:
-		return "", errors.New("mysql: unsupported isolation level: " + string(level))
+		return "", fmt.Errorf("mysql: unsupported isolation level: %v", level)
 	}
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -103,10 +103,10 @@
 			"revisionTime": "2017-01-17T22:23:42Z"
 		},
 		{
-			"checksumSHA1": "ZbU8qGzETzJZ2t30LmHxla5PLMY=",
+			"checksumSHA1": "K6icEVf2CuBzhLm/MGpRd1btshM=",
 			"path": "github.com/go-sql-driver/mysql",
-			"revision": "bc14601d1bd56421dd60f561e6052c9ed77f9daf",
-			"revisionTime": "2018-01-25T05:47:45Z"
+			"revision": "1a676ac6e4dce68e9303a1800773861350374a9e",
+			"revisionTime": "2018-03-08T10:03:10Z"
 		},
 		{
 			"checksumSHA1": "KZ3QD2QgUS4RcoKiA3mn5pSlJxQ=",


### PR DESCRIPTION
Continue from #44 (31487e7)
- messages are logged to separate files based on their log level, as done in #35 for eth-monitor
- logrotate function implemented
- 1st human-readable timestamp column is removed from log messages. now, only epoch times are logged.
- some small changes on node-finder options