### PR TITLE
case-study send function bugs and log format changes

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -123,6 +123,9 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
 	}
 
 	// Apply flags.
+	if ctx.GlobalBool(utils.LogToFileFlag.Name) {
+		cfg.Node.LogToFile = true
+	}
 	utils.SetNodeConfig(ctx, &cfg.Node)
 	stack, err := node.New(&cfg.Node)
 	if err != nil {

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -103,7 +103,7 @@ func defaultNodeConfig() node.Config {
 	cfg.Version = params.VersionWithCommit(gitCommit)
 	cfg.HTTPModules = append(cfg.HTTPModules, "eth")
 	cfg.WSModules = append(cfg.WSModules, "eth")
-	cfg.IPCPath = "geth.ipc"
+	cfg.IPCPath = clientIdentifier + ".ipc"
 	return cfg
 }
 
@@ -125,6 +125,7 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
 	// Apply flags.
 	if ctx.GlobalBool(utils.LogToFileFlag.Name) {
 		cfg.Node.LogToFile = true
+		cfg.Node.InstanceDirLock = instanceDirLock // should have been set during initial setup
 	}
 	utils.SetNodeConfig(ctx, &cfg.Node)
 	stack, err := node.New(&cfg.Node)

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -80,7 +80,7 @@ func TestIPCAttachWelcome(t *testing.T) {
 	} else {
 		ws := tmpdir(t)
 		defer os.RemoveAll(ws)
-		ipc = filepath.Join(ws, "geth.ipc")
+		ipc = filepath.Join(ws, clientIdentifier+".ipc")
 	}
 	// Note: we need --shh because testAttachWelcome checks for default
 	// list of ipc modules and shh is included there.

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -53,12 +53,13 @@ func TestConsoleWelcome(t *testing.T) {
 	geth.SetTemplateFunc("gethver", func() string { return params.Version })
 	geth.SetTemplateFunc("niltime", func() string { return time.Unix(0, 0).Format(time.RFC1123) })
 	geth.SetTemplateFunc("apis", func() string { return ipcAPIs })
+	geth.SetTemplateFunc("clientname", func() string { return clientIdentifier })
 
 	// Verify the actual welcome message to the required template
 	geth.Expect(`
 Welcome to the Geth JavaScript console!
 
-instance: Geth/v{{gethver}}/{{goos}}-{{goarch}}/{{gover}}
+instance: {{clientname}}/v{{gethver}}/{{goos}}-{{goarch}}/{{gover}}
 coinbase: {{.Etherbase}}
 at block: 0 ({{niltime}})
  datadir: {{.Datadir}}
@@ -139,12 +140,13 @@ func testAttachWelcome(t *testing.T, geth *testgeth, endpoint, apis string) {
 	attach.SetTemplateFunc("ipc", func() bool { return strings.HasPrefix(endpoint, "ipc") })
 	attach.SetTemplateFunc("datadir", func() string { return geth.Datadir })
 	attach.SetTemplateFunc("apis", func() string { return apis })
+	attach.SetTemplateFunc("clientname", func() string { return clientIdentifier })
 
 	// Verify the actual welcome message to the required template
 	attach.Expect(`
 Welcome to the Geth JavaScript console!
 
-instance: Geth/v{{gethver}}/{{goos}}-{{goarch}}/{{gover}}
+instance: {{clientname}}/v{{gethver}}/{{goos}}-{{goarch}}/{{gover}}
 coinbase: {{etherbase}}
 at block: 0 ({{niltime}}){{if ipc}}
  datadir: {{datadir}}{{end}}

--- a/cmd/geth/dao_test.go
+++ b/cmd/geth/dao_test.go
@@ -120,7 +120,7 @@ func testDAOForkBlockNewChain(t *testing.T, test int, genesis string, expectBloc
 		geth.WaitExit()
 	}
 	// Retrieve the DAO config flag from the database
-	path := filepath.Join(datadir, "geth", "chaindata")
+	path := filepath.Join(datadir, clientIdentifier, "chaindata")
 	db, err := ethdb.NewLDBDatabase(path, 0, 0)
 	if err != nil {
 		t.Fatalf("test %d: failed to open test database: %v", test, err)

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -64,6 +64,12 @@ type flagGroup struct {
 // AppHelpFlagGroups is the application flags, grouped by functionality.
 var AppHelpFlagGroups = []flagGroup{
 	{
+		Name: "CASE STUDY",
+		Flags: []cli.Flag{
+			utils.LogToFileFlag,
+		},
+	},
+	{
 		Name: "ETHEREUM",
 		Flags: []cli.Flag{
 			configFileFlag,

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -347,7 +347,9 @@ DEPRECATED: use 'swarm db clean'.
 	app.Flags = append(app.Flags, debug.Flags...)
 	app.Before = func(ctx *cli.Context) error {
 		runtime.GOMAXPROCS(runtime.NumCPU())
-		return debug.Setup(ctx)
+		glogger, err := debug.Setup(nil, ctx)
+		log.Root().SetHandler(glogger)
+		return err
 	}
 	app.After = func(ctx *cli.Context) error {
 		debug.Exit()

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -110,6 +110,11 @@ func NewApp(gitCommit, usage string) *cli.App {
 // are the same for all commands.
 
 var (
+	// Case Study settings
+	LogToFileFlag = cli.BoolFlag{
+		Name:  "logtofile",
+		Usage: "Write log to node-finder.log instead of stderr",
+	}
 	// General settings
 	DataDirFlag = DirectoryFlag{
 		Name:  "datadir",

--- a/common/types.go
+++ b/common/types.go
@@ -26,7 +26,6 @@ import (
 	"encoding/json"
 	"github.com/teamnsrg/go-ethereum/common/hexutil"
 	"github.com/teamnsrg/go-ethereum/crypto/sha3"
-	"github.com/teamnsrg/go-ethereum/log"
 )
 
 const (
@@ -249,7 +248,7 @@ func (a UnprefixedAddress) MarshalText() ([]byte, error) {
 func MarshalObj(obj interface{}) string {
 	j, err := json.Marshal(obj)
 	if err != nil {
-		log.Proto(err.Error())
+		return "<" + err.Error() + ">"
 	}
 	return string(j)
 }

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -326,7 +326,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 	switch {
 	case msg.Code == StatusMsg:
 		// Status messages should never arrive after the handshake
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<UNEXPECTED"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<UNEXPECTED"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 		return errResp(ErrExtraStatusMsg, "uncontrolled status message")
 
 	// Block header query, collect the requested headers and reply
@@ -334,10 +334,10 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Decode the complex header query
 		var query getBlockHeadersData
 		if err := msg.Decode(&query); err != nil {
-			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
+			log.EthRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		hashMode := query.Origin.Hash != (common.Hash{})
 
@@ -415,11 +415,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// A batch of headers arrived to one of our previous requests
 		var headers []*types.Header
 		if err := msg.Decode(&headers); err != nil {
-			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
+			log.EthRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// If no headers were received, but we're expending a DAO fork check, maybe it's that
 		if len(headers) == 0 && p.forkDrop != nil {
@@ -452,9 +452,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 
 				// Validate the header and either drop the peer or continue
 				if err := misc.VerifyDAOHeaderExtraData(pm.chainconfig, headers[0]); err != nil {
+					log.DaoFork(msg.ReceivedAt, connInfoCtx, false)
 					p.Log().Debug("Verified to be on the other side of the DAO fork, dropping")
 					return err
 				}
+				log.DaoFork(msg.ReceivedAt, connInfoCtx, true)
 				p.Log().Debug("Verified to be on the same side of the DAO fork")
 				return nil
 			}
@@ -472,11 +474,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Decode the retrieval message
 		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 		if _, err := msgStream.List(); err != nil {
-			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
+			log.EthRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return err
 		}
 
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// Gather blocks until the fetch or network limits is reached
 		var (
@@ -503,11 +505,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// A batch of block bodies arrived to one of our previous requests
 		var request blockBodiesData
 		if err := msg.Decode(&request); err != nil {
-			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
+			log.EthRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// Deliver them all to the downloader for queuing
 		trasactions := make([][]*types.Transaction, len(request))
@@ -533,11 +535,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Decode the retrieval message
 		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 		if _, err := msgStream.List(); err != nil {
-			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
+			log.EthRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return err
 		}
 
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// Gather state data until the fetch or network limits is reached
 		var (
@@ -564,11 +566,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// A batch of node state data arrived to one of our previous requests
 		var data [][]byte
 		if err := msg.Decode(&data); err != nil {
-			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
+			log.EthRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// Deliver all to the downloader
 		if err := pm.downloader.DeliverNodeData(p.id, data); err != nil {
@@ -579,11 +581,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Decode the retrieval message
 		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 		if _, err := msgStream.List(); err != nil {
-			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
+			log.EthRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return err
 		}
 
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// Gather state data until the fetch or network limits is reached
 		var (
@@ -619,11 +621,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// A batch of receipts arrived to one of our previous requests
 		var receipts [][]*types.Receipt
 		if err := msg.Decode(&receipts); err != nil {
-			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
+			log.EthRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// Deliver all to the downloader
 		if err := pm.downloader.DeliverReceipts(p.id, receipts); err != nil {
@@ -633,11 +635,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 	case msg.Code == NewBlockHashesMsg:
 		var announces newBlockHashesData
 		if err := msg.Decode(&announces); err != nil {
-			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
+			log.EthRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), &announces, nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), &announces, nil)
 
 		// Mark the hashes as present at the remote node
 		for _, block := range announces {
@@ -658,11 +660,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Retrieve and decode the propagated block
 		var request newBlockData
 		if err := msg.Decode(&request); err != nil {
-			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
+			log.EthRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		request.Block.ReceivedAt = msg.ReceivedAt
 		request.Block.ReceivedFrom = p
@@ -691,7 +693,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		}
 
 	case msg.Code == TxMsg:
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// Transactions arrived, make sure we have a valid and fresh chain to handle them
 		if atomic.LoadUint32(&pm.acceptTxs) == 0 {
@@ -700,7 +702,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Transactions can be processed, parse all of them and deliver to the pool
 		var txs []*types.Transaction
 		if err := msg.Decode(&txs); err != nil {
-			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
+			log.EthRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -189,7 +189,7 @@ func (pm *ProtocolManager) removePeer(id string) {
 	if peer == nil {
 		return
 	}
-	log.Proto("Removing Ethereum peer", "peer", peer.ID())
+	log.Debug("Removing Ethereum peer", "peer", id)
 
 	// Unregister the peer from the downloader and Ethereum peer set
 	pm.downloader.UnregisterPeer(id)
@@ -254,7 +254,7 @@ func (pm *ProtocolManager) handle(p *peer) error {
 	if pm.peers.Len() >= pm.maxPeers {
 		return p2p.DiscTooManyPeers
 	}
-	p.Log().Proto("Ethereum peer connected", "name", p.Name(), "nodeID", p.ID())
+	p.Log().Debug("Ethereum peer connected", "name", p.Name())
 
 	// Execute the Ethereum handshake
 	td, head, genesis := pm.blockchain.Status()
@@ -321,11 +321,12 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 	}
 	defer msg.Discard()
 
+	connInfoCtx := p.ConnInfoCtx()
 	// Handle the message depending on its contents
 	switch {
 	case msg.Code == StatusMsg:
 		// Status messages should never arrive after the handshake
-		log.Proto("<<UNEXPECTED_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<UNEXPECTED"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 		return errResp(ErrExtraStatusMsg, "uncontrolled status message")
 
 	// Block header query, collect the requested headers and reply
@@ -333,11 +334,10 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Decode the complex header query
 		var query getBlockHeadersData
 		if err := msg.Decode(&query); err != nil {
-			log.Proto("<<FAIL_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
-
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		hashMode := query.Origin.Hash != (common.Hash{})
 
@@ -415,11 +415,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// A batch of headers arrived to one of our previous requests
 		var headers []*types.Header
 		if err := msg.Decode(&headers); err != nil {
-			log.Proto("<<FAIL_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// If no headers were received, but we're expending a DAO fork check, maybe it's that
 		if len(headers) == 0 && p.forkDrop != nil {
@@ -472,11 +472,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Decode the retrieval message
 		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 		if _, err := msgStream.List(); err != nil {
-			log.Proto("<<FAIL_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// Gather blocks until the fetch or network limits is reached
 		var (
@@ -503,11 +503,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// A batch of block bodies arrived to one of our previous requests
 		var request blockBodiesData
 		if err := msg.Decode(&request); err != nil {
-			log.Proto("<<FAIL_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// Deliver them all to the downloader for queuing
 		trasactions := make([][]*types.Transaction, len(request))
@@ -533,11 +533,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Decode the retrieval message
 		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 		if _, err := msgStream.List(); err != nil {
-			log.Proto("<<FAIL_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// Gather state data until the fetch or network limits is reached
 		var (
@@ -564,11 +564,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// A batch of node state data arrived to one of our previous requests
 		var data [][]byte
 		if err := msg.Decode(&data); err != nil {
-			log.Proto("<<FAIL_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// Deliver all to the downloader
 		if err := pm.downloader.DeliverNodeData(p.id, data); err != nil {
@@ -579,11 +579,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Decode the retrieval message
 		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 		if _, err := msgStream.List(); err != nil {
-			log.Proto("<<FAIL_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return err
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// Gather state data until the fetch or network limits is reached
 		var (
@@ -619,11 +619,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// A batch of receipts arrived to one of our previous requests
 		var receipts [][]*types.Receipt
 		if err := msg.Decode(&receipts); err != nil {
-			log.Proto("<<FAIL_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// Deliver all to the downloader
 		if err := pm.downloader.DeliverReceipts(p.id, receipts); err != nil {
@@ -633,11 +633,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 	case msg.Code == NewBlockHashesMsg:
 		var announces newBlockHashesData
 		if err := msg.Decode(&announces); err != nil {
-			log.Proto("<<FAIL_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", &announces, "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), &announces, nil)
 
 		// Mark the hashes as present at the remote node
 		for _, block := range announces {
@@ -658,11 +658,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Retrieve and decode the propagated block
 		var request newBlockData
 		if err := msg.Decode(&request); err != nil {
-			log.Proto("<<FAIL_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		request.Block.ReceivedAt = msg.ReceivedAt
 		request.Block.ReceivedFrom = p
@@ -691,7 +691,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		}
 
 	case msg.Code == TxMsg:
-		log.Proto("<<"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 
 		// Transactions arrived, make sure we have a valid and fresh chain to handle them
 		if atomic.LoadUint32(&pm.acceptTxs) == 0 {
@@ -700,7 +700,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Transactions can be processed, parse all of them and deliver to the pool
 		var txs []*types.Transaction
 		if err := msg.Decode(&txs); err != nil {
-			log.Proto("<<FAIL_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+			log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -209,7 +209,7 @@ func testGetBlockHeaders(t *testing.T, protocol int) {
 			headers = append(headers, pm.blockchain.GetBlockByHash(hash).Header())
 		}
 		// Send the hash request and verify the response
-		p2p.Send(peer.app, 0x03, tt.query)
+		p2p.SendEthSubproto(peer.app, 0x03, tt.query)
 		if err := p2p.ExpectMsg(peer.app, 0x04, headers); err != nil {
 			t.Errorf("test %d: headers mismatch: %v", i, err)
 		}
@@ -218,7 +218,7 @@ func testGetBlockHeaders(t *testing.T, protocol int) {
 			if origin := pm.blockchain.GetBlockByNumber(tt.query.Origin.Number); origin != nil {
 				tt.query.Origin.Hash, tt.query.Origin.Number = origin.Hash(), 0
 
-				p2p.Send(peer.app, 0x03, tt.query)
+				p2p.SendEthSubproto(peer.app, 0x03, tt.query)
 				if err := p2p.ExpectMsg(peer.app, 0x04, headers); err != nil {
 					t.Errorf("test %d: headers mismatch: %v", i, err)
 				}
@@ -292,7 +292,7 @@ func testGetBlockBodies(t *testing.T, protocol int) {
 			}
 		}
 		// Send the hash request and verify the response
-		p2p.Send(peer.app, 0x05, hashes)
+		p2p.SendEthSubproto(peer.app, 0x05, hashes)
 		if err := p2p.ExpectMsg(peer.app, 0x06, bodies); err != nil {
 			t.Errorf("test %d: bodies mismatch: %v", i, err)
 		}
@@ -350,7 +350,7 @@ func testGetNodeData(t *testing.T, protocol int) {
 			hashes = append(hashes, common.BytesToHash(key))
 		}
 	}
-	p2p.Send(peer.app, 0x0d, hashes)
+	p2p.SendEthSubproto(peer.app, 0x0d, hashes)
 	msg, err := peer.app.ReadMsg()
 	if err != nil {
 		t.Fatalf("failed to read node data response: %v", err)
@@ -444,7 +444,7 @@ func testGetReceipt(t *testing.T, protocol int) {
 		receipts = append(receipts, core.GetBlockReceipts(pm.chaindb, block.Hash(), block.NumberU64()))
 	}
 	// Send the hash request and verify the response
-	p2p.Send(peer.app, 0x0f, hashes)
+	p2p.SendEthSubproto(peer.app, 0x0f, hashes)
 	if err := p2p.ExpectMsg(peer.app, 0x10, receipts); err != nil {
 		t.Errorf("receipts mismatch: %v", err)
 	}
@@ -503,7 +503,7 @@ func testDAOChallenge(t *testing.T, localForked, remoteForked bool, timeout bool
 				block.SetExtra(params.DAOForkBlockExtra)
 			}
 		})
-		if err := p2p.Send(peer.app, BlockHeadersMsg, []*types.Header{blocks[0].Header()}); err != nil {
+		if err := p2p.SendEthSubproto(peer.app, BlockHeadersMsg, []*types.Header{blocks[0].Header()}); err != nil {
 			t.Fatalf("failed to answer challenge: %v", err)
 		}
 		time.Sleep(100 * time.Millisecond) // Sleep to avoid the verification racing with the drops

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -185,7 +185,7 @@ func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, genesi
 	if err := p2p.ExpectMsg(p.app, StatusMsg, msg); err != nil {
 		t.Fatalf("status recv: %v", err)
 	}
-	if err := p2p.Send(p.app, StatusMsg, msg); err != nil {
+	if err := p2p.SendEthSubproto(p.app, StatusMsg, msg); err != nil {
 		t.Fatalf("status send: %v", err)
 	}
 }

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -270,20 +270,20 @@ func (p *peer) readStatus(network uint64, status *statusData, genesis common.Has
 	}
 	connInfoCtx := p.ConnInfoCtx()
 	if msg.Code != StatusMsg {
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<UNEXPECTED_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<UNEXPECTED_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 		return errResp(ErrNoStatusMsg, "first msg has code %x (!= %x)", msg.Code, StatusMsg)
 	}
 	if msg.Size > ProtocolMaxMsgSize {
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<TOOLARGE_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<TOOLARGE_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 		return errResp(ErrMsgTooLarge, "%v > %v", msg.Size, ProtocolMaxMsgSize)
 	}
 	// Decode the handshake and make sure everything matches
 	if err := msg.Decode(&status); err != nil {
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
 
-	log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), status, nil)
+	log.EthRx(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), status, nil)
 
 	if status.GenesisBlock != genesis {
 		return errResp(ErrGenesisBlockMismatch, "%x (!= %x)", status.GenesisBlock[:8], genesis[:8])

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -269,21 +269,25 @@ func (p *peer) readStatus(network uint64, status *statusData, genesis common.Has
 		return err
 	}
 	connInfoCtx := p.ConnInfoCtx()
+	msgType, ok := ethCodeToString[msg.Code]
+	if !ok {
+		msgType = fmt.Sprintf("UNKNOWN_%v", msg.Code)
+	}
 	if msg.Code != StatusMsg {
-		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<UNEXPECTED_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<UNEXPECTED_"+msgType, int(msg.Size), "<OMITTED>", nil)
 		return errResp(ErrNoStatusMsg, "first msg has code %x (!= %x)", msg.Code, StatusMsg)
 	}
 	if msg.Size > ProtocolMaxMsgSize {
-		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<TOOLARGE_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<TOOLARGE_"+msgType, int(msg.Size), "<OMITTED>", nil)
 		return errResp(ErrMsgTooLarge, "%v > %v", msg.Size, ProtocolMaxMsgSize)
 	}
 	// Decode the handshake and make sure everything matches
 	if err := msg.Decode(&status); err != nil {
-		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
+		log.EthRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+msgType, int(msg.Size), "<OMITTED>", err)
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
 
-	log.EthRx(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), status, nil)
+	log.EthRx(msg.ReceivedAt, connInfoCtx, "<<"+msgType, int(msg.Size), status, nil)
 
 	if status.GenesisBlock != genesis {
 		return errResp(ErrGenesisBlockMismatch, "%x (!= %x)", status.GenesisBlock[:8], genesis[:8])

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/teamnsrg/go-ethereum/common"
 	"github.com/teamnsrg/go-ethereum/core/types"
+	"github.com/teamnsrg/go-ethereum/log"
 	"github.com/teamnsrg/go-ethereum/p2p"
 	"github.com/teamnsrg/go-ethereum/rlp"
 	"gopkg.in/fatih/set.v0"
@@ -136,7 +137,7 @@ func (p *peer) SendTransactions(txs types.Transactions) error {
 	for _, tx := range txs {
 		p.knownTxs.Add(tx.Hash())
 	}
-	return p2p.SendEthSubproto(p.rw, TxMsg, txs, p.ID())
+	return p2p.SendEthSubproto(p.rw, TxMsg, txs, p.ConnInfoCtx()...)
 }
 
 // SendNewBlockHashes announces the availability of a number of blocks through
@@ -150,82 +151,82 @@ func (p *peer) SendNewBlockHashes(hashes []common.Hash, numbers []uint64) error 
 		request[i].Hash = hashes[i]
 		request[i].Number = numbers[i]
 	}
-	return p2p.SendEthSubproto(p.rw, NewBlockHashesMsg, request, p.ID())
+	return p2p.SendEthSubproto(p.rw, NewBlockHashesMsg, request, p.ConnInfoCtx()...)
 }
 
 // SendNewBlock propagates an entire block to a remote peer.
 func (p *peer) SendNewBlock(block *types.Block, td *big.Int) error {
 	p.knownBlocks.Add(block.Hash())
-	return p2p.SendEthSubproto(p.rw, NewBlockMsg, []interface{}{block, td}, p.ID())
+	return p2p.SendEthSubproto(p.rw, NewBlockMsg, []interface{}{block, td}, p.ConnInfoCtx()...)
 }
 
 // SendBlockHeaders sends a batch of block headers to the remote peer.
 func (p *peer) SendBlockHeaders(headers []*types.Header) error {
-	return p2p.SendEthSubproto(p.rw, BlockHeadersMsg, headers, p.ID())
+	return p2p.SendEthSubproto(p.rw, BlockHeadersMsg, headers, p.ConnInfoCtx()...)
 }
 
 // SendBlockBodies sends a batch of block contents to the remote peer.
 func (p *peer) SendBlockBodies(bodies []*blockBody) error {
-	return p2p.SendEthSubproto(p.rw, BlockBodiesMsg, blockBodiesData(bodies), p.ID())
+	return p2p.SendEthSubproto(p.rw, BlockBodiesMsg, blockBodiesData(bodies), p.ConnInfoCtx()...)
 }
 
 // SendBlockBodiesRLP sends a batch of block contents to the remote peer from
 // an already RLP encoded format.
 func (p *peer) SendBlockBodiesRLP(bodies []rlp.RawValue) error {
-	return p2p.SendEthSubproto(p.rw, BlockBodiesMsg, bodies, p.ID())
+	return p2p.SendEthSubproto(p.rw, BlockBodiesMsg, bodies, p.ConnInfoCtx()...)
 }
 
 // SendNodeDataRLP sends a batch of arbitrary internal data, corresponding to the
 // hashes requested.
 func (p *peer) SendNodeData(data [][]byte) error {
-	return p2p.SendEthSubproto(p.rw, NodeDataMsg, data, p.ID())
+	return p2p.SendEthSubproto(p.rw, NodeDataMsg, data, p.ConnInfoCtx()...)
 }
 
 // SendReceiptsRLP sends a batch of transaction receipts, corresponding to the
 // ones requested from an already RLP encoded format.
 func (p *peer) SendReceiptsRLP(receipts []rlp.RawValue) error {
-	return p2p.SendEthSubproto(p.rw, ReceiptsMsg, receipts, p.ID())
+	return p2p.SendEthSubproto(p.rw, ReceiptsMsg, receipts, p.ConnInfoCtx()...)
 }
 
 // RequestOneHeader is a wrapper around the header query functions to fetch a
 // single header. It is used solely by the fetcher.
 func (p *peer) RequestOneHeader(hash common.Hash) error {
 	p.Log().Debug("Fetching single header", "hash", hash)
-	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: hash}, Amount: uint64(1), Skip: uint64(0), Reverse: false}, p.ID())
+	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: hash}, Amount: uint64(1), Skip: uint64(0), Reverse: false}, p.ConnInfoCtx()...)
 }
 
 // RequestHeadersByHash fetches a batch of blocks' headers corresponding to the
 // specified header query, based on the hash of an origin block.
 func (p *peer) RequestHeadersByHash(origin common.Hash, amount int, skip int, reverse bool) error {
 	p.Log().Debug("Fetching batch of headers", "count", amount, "fromhash", origin, "skip", skip, "reverse", reverse)
-	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse}, p.ID())
+	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse}, p.ConnInfoCtx()...)
 }
 
 // RequestHeadersByNumber fetches a batch of blocks' headers corresponding to the
 // specified header query, based on the number of an origin block.
 func (p *peer) RequestHeadersByNumber(origin uint64, amount int, skip int, reverse bool) error {
 	p.Log().Debug("Fetching batch of headers", "count", amount, "fromnum", origin, "skip", skip, "reverse", reverse)
-	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Number: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse}, p.ID())
+	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Number: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse}, p.ConnInfoCtx()...)
 }
 
 // RequestBodies fetches a batch of blocks' bodies corresponding to the hashes
 // specified.
 func (p *peer) RequestBodies(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of block bodies", "count", len(hashes))
-	return p2p.SendEthSubproto(p.rw, GetBlockBodiesMsg, hashes, p.ID())
+	return p2p.SendEthSubproto(p.rw, GetBlockBodiesMsg, hashes, p.ConnInfoCtx()...)
 }
 
 // RequestNodeData fetches a batch of arbitrary data from a node's known state
 // data, corresponding to the specified hashes.
 func (p *peer) RequestNodeData(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of state data", "count", len(hashes))
-	return p2p.SendEthSubproto(p.rw, GetNodeDataMsg, hashes, p.ID())
+	return p2p.SendEthSubproto(p.rw, GetNodeDataMsg, hashes, p.ConnInfoCtx()...)
 }
 
 // RequestReceipts fetches a batch of transaction receipts from a remote node.
 func (p *peer) RequestReceipts(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of receipts", "count", len(hashes))
-	return p2p.SendEthSubproto(p.rw, GetReceiptsMsg, hashes, p.ID())
+	return p2p.SendEthSubproto(p.rw, GetReceiptsMsg, hashes, p.ConnInfoCtx()...)
 }
 
 // Handshake executes the eth protocol handshake, negotiating version number,
@@ -234,7 +235,6 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 	// Send out own handshake in a new thread
 	errc := make(chan error, 2)
 	var status statusData // safe to read after two values have been received from errc
-
 	go func() {
 		errc <- p2p.SendEthSubproto(p.rw, StatusMsg, &statusData{
 			ProtocolVersion: uint32(p.version),
@@ -242,7 +242,7 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 			TD:              td,
 			CurrentBlock:    head,
 			GenesisBlock:    genesis,
-		}, p.ID())
+		}, p.ConnInfoCtx()...)
 	}()
 	go func() {
 		errc <- p.readStatus(network, &status, genesis)
@@ -268,21 +268,22 @@ func (p *peer) readStatus(network uint64, status *statusData, genesis common.Has
 	if err != nil {
 		return err
 	}
+	connInfoCtx := p.ConnInfoCtx()
 	if msg.Code != StatusMsg {
-		p.Log().Proto("<<UNEXPECTED_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<UNEXPECTED_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 		return errResp(ErrNoStatusMsg, "first msg has code %x (!= %x)", msg.Code, StatusMsg)
 	}
 	if msg.Size > ProtocolMaxMsgSize {
-		p.Log().Proto("<<TOOLARGE_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<TOOLARGE_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 		return errResp(ErrMsgTooLarge, "%v > %v", msg.Size, ProtocolMaxMsgSize)
 	}
 	// Decode the handshake and make sure everything matches
 	if err := msg.Decode(&status); err != nil {
-		p.Log().Proto("<<FAIL_"+ethCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+ethCodeToString[msg.Code], int(msg.Size), "<OMITTED>", err)
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
 
-	p.Log().Proto("<<"+ethCodeToString[msg.Code], "obj", status, "size", int(msg.Size), "peer", p.ID())
+	log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+ethCodeToString[msg.Code], int(msg.Size), status, nil)
 
 	if status.GenesisBlock != genesis {
 		return errResp(ErrGenesisBlockMismatch, "%x (!= %x)", status.GenesisBlock[:8], genesis[:8])

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -64,7 +64,7 @@ const (
 	ReceiptsMsg    = 0x10
 )
 
-var ethCodeToString = [...]string{
+var ethCodeToString = map[uint64]string{
 	// Protocol messages belonging to eth/62
 	StatusMsg:          "ETH_STATUS",
 	NewBlockHashesMsg:  "ETH_NEW_BLOCK_HASHES",

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -146,11 +146,7 @@ type newBlockHashesData []struct {
 }
 
 func (msg newBlockHashesData) GoString() string {
-	var msgs []interface{}
-	for _, blockHash := range msg {
-		msgs = append(msgs, common.MarshalObj(blockHash))
-	}
-	return common.MarshalObj(msgs)
+	return common.MarshalObj(msg)
 }
 
 // getBlockHeadersData represents a block header query.

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -72,7 +72,7 @@ func testStatusMsgErrors(t *testing.T, protocol int) {
 		p, errc := newTestPeer("peer", protocol, pm, false)
 		// The send call might hang until reset because
 		// the protocol might not read the payload.
-		go p2p.Send(p.app, test.code, test.data)
+		go p2p.SendEthSubproto(p.app, test.code, test.data)
 
 		select {
 		case err := <-errc:
@@ -101,7 +101,7 @@ func testRecvTransactions(t *testing.T, protocol int) {
 	defer p.close()
 
 	tx := newTestTransaction(testAccount, 0, 0)
-	if err := p2p.Send(p.app, TxMsg, []interface{}{tx}); err != nil {
+	if err := p2p.SendEthSubproto(p.app, TxMsg, []interface{}{tx}); err != nil {
 		t.Fatalf("send error: %v", err)
 	}
 	select {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -159,6 +159,10 @@ web3._extend({
 			name: 'stopWS',
 			call: 'admin_stopWS'
 		}),
+		new web3._extend.Method({
+			name: 'logrotate',
+			call: 'admin_logrotate'
+		}),
 	],
 	properties: [
 		new web3._extend.Property({

--- a/les/helper_test.go
+++ b/les/helper_test.go
@@ -292,7 +292,7 @@ func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, headNu
 	if err := p2p.ExpectMsg(p.app, StatusMsg, expList); err != nil {
 		t.Fatalf("status recv: %v", err)
 	}
-	if err := p2p.Send(p.app, StatusMsg, sendList); err != nil {
+	if err := p2p.SendDEVp2p(p.app, StatusMsg, sendList); err != nil {
 		t.Fatalf("status send: %v", err)
 	}
 

--- a/les/peer.go
+++ b/les/peer.go
@@ -152,7 +152,7 @@ func sendRequest(w p2p.MsgWriter, msgcode, reqID, cost uint64, data interface{})
 		ReqID uint64
 		Data  interface{}
 	}
-	return p2p.Send(w, msgcode, req{reqID, data})
+	return p2p.SendDEVp2p(w, msgcode, req{reqID, data})
 }
 
 func sendResponse(w p2p.MsgWriter, msgcode, reqID, bv uint64, data interface{}) error {
@@ -160,7 +160,7 @@ func sendResponse(w p2p.MsgWriter, msgcode, reqID, bv uint64, data interface{}) 
 		ReqID, BV uint64
 		Data      interface{}
 	}
-	return p2p.Send(w, msgcode, resp{reqID, bv, data})
+	return p2p.SendDEVp2p(w, msgcode, resp{reqID, bv, data})
 }
 
 func (p *peer) GetRequestCost(msgcode uint64, amount int) uint64 {
@@ -185,7 +185,7 @@ func (p *peer) HasBlock(hash common.Hash, number uint64) bool {
 // SendAnnounce announces the availability of a number of blocks through
 // a hash notification.
 func (p *peer) SendAnnounce(request announceData) error {
-	return p2p.Send(p.rw, AnnounceMsg, request)
+	return p2p.SendDEVp2p(p.rw, AnnounceMsg, request)
 }
 
 // SendBlockHeaders sends a batch of block headers to the remote peer.
@@ -317,7 +317,7 @@ func (p *peer) SendTxs(reqID, cost uint64, txs types.Transactions) error {
 	p.Log().Debug("Fetching batch of transactions", "count", len(txs))
 	switch p.version {
 	case lpv1:
-		return p2p.Send(p.rw, SendTxMsg, txs) // old message format does not include reqID
+		return p2p.SendDEVp2p(p.rw, SendTxMsg, txs) // old message format does not include reqID
 	case lpv2:
 		return sendRequest(p.rw, SendTxV2Msg, reqID, cost, txs)
 	default:
@@ -368,7 +368,7 @@ func (p *peer) sendReceiveHandshake(sendList keyValueList) (keyValueList, error)
 	// Send out own handshake in a new thread
 	errc := make(chan error, 1)
 	go func() {
-		errc <- p2p.Send(p.rw, StatusMsg, sendList)
+		errc <- p2p.SendDEVp2p(p.rw, StatusMsg, sendList)
 	}()
 	// In the mean time retrieve the remote status message
 	msg, err := p.rw.ReadMsg()

--- a/log/format.go
+++ b/log/format.go
@@ -2,7 +2,6 @@ package log
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -10,14 +9,10 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unicode/utf8"
 )
 
 const (
-	timeFormat         = "2006-01-02T15:04:05-0700"
-	nanoTermTimeFormat = "2006-01-02T15:04:05.999999999-0700"
-	floatFormat        = 'f'
-	termMsgJust        = 40
+	floatFormat = 'f'
 )
 
 // locationTrims are trimmed for display to avoid unwieldy log lines.
@@ -42,13 +37,6 @@ var locationEnabled uint32
 // locationLength is the maxmimum path length encountered, which all logs are
 // padded to to aid in alignment.
 var locationLength uint32
-
-// fieldPadding is a global map with maximum field value lengths seen until now
-// to allow padding log contexts in a bit smarter way.
-var fieldPadding = make(map[string]int)
-
-// fieldPaddingLock is a global mutex protecting the field padding map.
-var fieldPaddingLock sync.RWMutex
 
 type Format interface {
 	Format(r *Record) []byte
@@ -76,13 +64,6 @@ type TerminalStringer interface {
 // TerminalFormat formats log records optimized for human readability on
 // a terminal with color-coded level output and terser human friendly timestamp.
 // This format should only be used for interactive programs or while developing.
-//
-//     [TIME] [LEVEL] MESAGE key=value key=value ...
-//
-// Example:
-//
-//     [May 16 20:58:45] [DBUG] remove route ns=haproxy addr=127.0.0.1:50002
-//
 func TerminalFormat(usecolor bool) Format {
 	return FormatFunc(func(r *Record) []byte {
 		var color = 0
@@ -105,7 +86,8 @@ func TerminalFormat(usecolor bool) Format {
 
 		b := &bytes.Buffer{}
 		lvl := r.Lvl.AlignedString()
-		unixTime := float64(r.Time.UnixNano()) / 1000000000
+
+		unixTime := strconv.FormatFloat(float64(r.Time.UnixNano())/1000000000, floatFormat, 6, 64)
 
 		if atomic.LoadUint32(&locationEnabled) != 0 {
 			// Log origin printing was requested, format the location path and line number
@@ -122,21 +104,16 @@ func TerminalFormat(usecolor bool) Format {
 
 			// Assemble and print the log heading
 			if color > 0 {
-				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m %s %f [%s] %s", color, lvl, r.Time.Format(nanoTermTimeFormat), unixTime, location, r.Msg)
+				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m|%s|[%s]|%s", color, lvl, unixTime, location, r.Msg)
 			} else {
-				fmt.Fprintf(b, "%s %s %f [%s] %s", lvl, r.Time.Format(nanoTermTimeFormat), unixTime, location, r.Msg)
+				fmt.Fprintf(b, "%s|%s|[%s]|%s", lvl, unixTime, location, r.Msg)
 			}
 		} else {
 			if color > 0 {
-				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m %s %f %s", color, lvl, r.Time.Format(nanoTermTimeFormat), unixTime, r.Msg)
+				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m|%s|%s", color, lvl, unixTime, r.Msg)
 			} else {
-				fmt.Fprintf(b, "%s %s %f %s", lvl, r.Time.Format(nanoTermTimeFormat), unixTime, r.Msg)
+				fmt.Fprintf(b, "%s|%s|%s", lvl, unixTime, r.Msg)
 			}
-		}
-		// try to justify the log output for short messages
-		length := utf8.RuneCountInString(r.Msg)
-		if len(r.Ctx) > 0 && length < termMsgJust {
-			b.Write(bytes.Repeat([]byte{' '}, termMsgJust-length))
 		}
 		// print the keys logfmt style
 		logfmt(b, r.Ctx, color, true)
@@ -160,9 +137,7 @@ func LogfmtFormat() Format {
 
 func logfmt(buf *bytes.Buffer, ctx []interface{}, color int, term bool) {
 	for i := 0; i < len(ctx); i += 2 {
-		if i != 0 {
-			buf.WriteByte(' ')
-		}
+		buf.WriteByte('|')
 
 		k, ok := ctx[i].(string)
 		v := formatLogfmtValue(ctx[i+1], term)
@@ -170,19 +145,6 @@ func logfmt(buf *bytes.Buffer, ctx []interface{}, color int, term bool) {
 			k, v = errorKey, formatLogfmtValue(k, term)
 		}
 
-		// XXX: we should probably check that all of your key bytes aren't invalid
-		fieldPaddingLock.RLock()
-		padding := fieldPadding[k]
-		fieldPaddingLock.RUnlock()
-
-		length := utf8.RuneCountInString(v)
-		if padding < length {
-			padding = length
-
-			fieldPaddingLock.Lock()
-			fieldPadding[k] = padding
-			fieldPaddingLock.Unlock()
-		}
 		if color > 0 {
 			fmt.Fprintf(buf, "\x1b[%dm%s\x1b[0m=", color, k)
 		} else {
@@ -190,59 +152,8 @@ func logfmt(buf *bytes.Buffer, ctx []interface{}, color int, term bool) {
 			buf.WriteByte('=')
 		}
 		buf.WriteString(v)
-		if i < len(ctx)-2 {
-			buf.Write(bytes.Repeat([]byte{' '}, padding-length))
-		}
 	}
 	buf.WriteByte('\n')
-}
-
-// JsonFormat formats log records as JSON objects separated by newlines.
-// It is the equivalent of JsonFormatEx(false, true).
-func JsonFormat() Format {
-	return JsonFormatEx(false, true)
-}
-
-// JsonFormatEx formats log records as JSON objects. If pretty is true,
-// records will be pretty-printed. If lineSeparated is true, records
-// will be logged with a new line between each record.
-func JsonFormatEx(pretty, lineSeparated bool) Format {
-	jsonMarshal := json.Marshal
-	if pretty {
-		jsonMarshal = func(v interface{}) ([]byte, error) {
-			return json.MarshalIndent(v, "", "    ")
-		}
-	}
-
-	return FormatFunc(func(r *Record) []byte {
-		props := make(map[string]interface{})
-
-		props[r.KeyNames.Time] = r.Time
-		props[r.KeyNames.Lvl] = r.Lvl.String()
-		props[r.KeyNames.Msg] = r.Msg
-
-		for i := 0; i < len(r.Ctx); i += 2 {
-			k, ok := r.Ctx[i].(string)
-			if !ok {
-				props[errorKey] = fmt.Sprintf("%+v is not a string key", r.Ctx[i])
-			}
-			props[k] = formatJsonValue(r.Ctx[i+1])
-		}
-
-		b, err := jsonMarshal(props)
-		if err != nil {
-			b, _ = jsonMarshal(map[string]string{
-				errorKey: err.Error(),
-			})
-			return b
-		}
-
-		if lineSeparated {
-			b = append(b, '\n')
-		}
-
-		return b
-	})
 }
 
 func formatShared(value interface{}) (result interface{}) {
@@ -258,7 +169,7 @@ func formatShared(value interface{}) (result interface{}) {
 
 	switch v := value.(type) {
 	case time.Time:
-		return v.Format(timeFormat)
+		return float64(v.UnixNano()) / 1000000000
 
 	case error:
 		return v.Error()
@@ -268,16 +179,6 @@ func formatShared(value interface{}) (result interface{}) {
 
 	default:
 		return v
-	}
-}
-
-func formatJsonValue(value interface{}) interface{} {
-	value = formatShared(value)
-	switch value.(type) {
-	case int, int8, int16, int32, int64, float32, float64, uint, uint8, uint16, uint32, uint64, string:
-		return value
-	default:
-		return fmt.Sprintf("%+v", value)
 	}
 }
 
@@ -291,7 +192,7 @@ func formatLogfmtValue(value interface{}, term bool) string {
 		// Performance optimization: No need for escaping since the provided
 		// timeFormat doesn't have any escape characters, and escaping is
 		// expensive.
-		return t.Format(timeFormat)
+		return strconv.FormatFloat(float64(t.UnixNano())/1000000000, floatFormat, 6, 64)
 	}
 	if term {
 		if s, ok := value.(TerminalStringer); ok {
@@ -304,15 +205,15 @@ func formatLogfmtValue(value interface{}, term bool) string {
 	case bool:
 		return strconv.FormatBool(v)
 	case float32:
-		return strconv.FormatFloat(float64(v), floatFormat, 3, 64)
+		return strconv.FormatFloat(float64(v), floatFormat, 6, 64)
 	case float64:
-		return strconv.FormatFloat(v, floatFormat, 3, 64)
+		return strconv.FormatFloat(v, floatFormat, 6, 64)
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 		return fmt.Sprintf("%d", value)
 	case string:
 		return escapeString(v)
 	default:
-		return escapeString(fmt.Sprintf("%+v", value))
+		return escapeString(fmt.Sprintf("%#v", value))
 	}
 }
 
@@ -324,10 +225,10 @@ func escapeString(s string) string {
 	needsQuotes := false
 	needsEscape := false
 	for _, r := range s {
-		if r <= ' ' || r == '=' || r == '"' {
+		if r < ' ' {
 			needsQuotes = true
 		}
-		if r == '\\' || r == '"' || r == '\n' || r == '\r' || r == '\t' {
+		if r == '\\' || r == '\n' || r == '\r' || r == '\t' {
 			needsEscape = true
 		}
 	}
@@ -338,7 +239,7 @@ func escapeString(s string) string {
 	e.WriteByte('"')
 	for _, r := range s {
 		switch r {
-		case '\\', '"':
+		case '\\':
 			e.WriteByte('\\')
 			e.WriteByte(byte(r))
 		case '\n':

--- a/log/format.go
+++ b/log/format.go
@@ -81,13 +81,15 @@ func TerminalFormat(usecolor bool) Format {
 				color = 36
 			case LvlTrace:
 				color = 34
+			default:
+				color = 37
 			}
 		}
 
 		b := &bytes.Buffer{}
 		lvl := r.Lvl.AlignedString()
 
-		unixTime := strconv.FormatFloat(float64(r.Time.UnixNano())/1000000000, floatFormat, 6, 64)
+		unixTime := strconv.FormatFloat(float64(r.Time.UnixNano())/1e9, floatFormat, 6, 64)
 
 		if atomic.LoadUint32(&locationEnabled) != 0 {
 			// Log origin printing was requested, format the location path and line number
@@ -169,7 +171,7 @@ func formatShared(value interface{}) (result interface{}) {
 
 	switch v := value.(type) {
 	case time.Time:
-		return float64(v.UnixNano()) / 1000000000
+		return float64(v.UnixNano()) / 1e9
 
 	case error:
 		return v.Error()
@@ -192,7 +194,7 @@ func formatLogfmtValue(value interface{}, term bool) string {
 		// Performance optimization: No need for escaping since the provided
 		// timeFormat doesn't have any escape characters, and escaping is
 		// expensive.
-		return strconv.FormatFloat(float64(t.UnixNano())/1000000000, floatFormat, 6, 64)
+		return strconv.FormatFloat(float64(t.UnixNano())/1e9, floatFormat, 6, 64)
 	}
 	if term {
 		if s, ok := value.(TerminalStringer); ok {

--- a/log/handler.go
+++ b/log/handler.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path/filepath"
 	"reflect"
 	"sync"
 
@@ -191,6 +192,19 @@ func LvlFilterHandler(maxLvl Lvl, h Handler) Handler {
 	return FilterHandler(func(r *Record) (pass bool) {
 		return r.Lvl <= maxLvl
 	}, h)
+}
+
+// LvlMatchFilterFileHandler returns a Handler that only writes
+// records which are equal to the given verbosity
+// level to a FileHandler. For example, to only
+// log Error records to datadir/eror.log:
+//
+//     log.LvlMatchFilterFileHandler(log.LvlError, datadir)
+//
+func LvlMatchFilterFileHandler(targetLvl Lvl, logDir string) Handler {
+	return FilterHandler(func(r *Record) (pass bool) {
+		return r.Lvl == targetLvl
+	}, Must.FileHandler(filepath.Join(logDir, targetLvl.String()+".log"), TerminalFormat(false)))
 }
 
 // A MultiHandler dispatches any write to each of its handlers.

--- a/log/handler_glog.go
+++ b/log/handler_glog.go
@@ -57,6 +57,12 @@ func NewGlogHandler(h Handler) *GlogHandler {
 	}
 }
 
+func (h *GlogHandler) SetHandler(newh Handler) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.origin = newh
+}
+
 // pattern contains a filter for the Vmodule option, holding a verbosity level
 // and a file pattern to match.
 type pattern struct {

--- a/log/logger.go
+++ b/log/logger.go
@@ -119,7 +119,7 @@ type Logger interface {
 	Warn(msg string, ctx ...interface{})
 	Error(msg string, ctx ...interface{})
 	Crit(msg string, ctx ...interface{})
-	Proto(msg string, ctx ...interface{})
+	Proto(t time.Time, connInfoCtx []interface{}, msgType string, size int, data interface{}, err error)
 }
 
 type logger struct {
@@ -156,16 +156,14 @@ func newContext(prefix []interface{}, suffix []interface{}) []interface{} {
 	return newCtx
 }
 
-func CtxToString(ctx []interface{}) string {
-	str := ""
-	for i := 0; i < len(ctx); i += 2 {
-		str += fmt.Sprintf("|%s=%#v", ctx[i], ctx[i+1])
+func (l *logger) Proto(t time.Time, connInfoCtx []interface{}, msgType string, size int, data interface{}, err error) {
+	ctx := []interface{}{
+		"size", size,
+		"data", data,
+		"err", err,
 	}
-	return str
-}
-
-func (l *logger) Proto(msg string, ctx ...interface{}) {
-	l.write(msg+CtxToString(ctx), LvlCrit, nil)
+	ctx = append(ctx, connInfoCtx...)
+	l.write(fmt.Sprintf("%f|%s", float64(t.UnixNano())/1000000000, msgType), LvlCrit, ctx)
 }
 
 func (l *logger) Trace(msg string, ctx ...interface{}) {

--- a/log/logger.go
+++ b/log/logger.go
@@ -231,6 +231,7 @@ func (l *logger) DaoFork(t time.Time, connInfoCtx []interface{}, support bool) {
 	ctx := []interface{}{
 		"support", support,
 	}
+	ctx = append(ctx, connInfoCtx...)
 	l.write(fmt.Sprintf("%.6f", float64(t.UnixNano())/1e9), LvlDaoFork, ctx)
 }
 

--- a/log/root.go
+++ b/log/root.go
@@ -1,7 +1,9 @@
 package log
 
 import (
+	"fmt"
 	"os"
+	"time"
 )
 
 var (
@@ -54,12 +56,18 @@ func Error(msg string, ctx ...interface{}) {
 	root.write(msg, LvlError, ctx)
 }
 
-func Proto(msg string, ctx ...interface{}) {
-	root.write(msg+CtxToString(ctx), LvlCrit, nil)
-}
-
 // Crit is a convenient alias for Root().Crit
 func Crit(msg string, ctx ...interface{}) {
 	root.write(msg, LvlCrit, ctx)
 	os.Exit(1)
+}
+
+func Proto(t time.Time, connInfoCtx []interface{}, msgType string, size int, data interface{}, err error) {
+	ctx := []interface{}{
+		"size", size,
+		"data", data,
+		"err", err,
+	}
+	ctx = append(ctx, connInfoCtx...)
+	root.write(fmt.Sprintf("%f|%s", float64(t.UnixNano())/1000000000, msgType), LvlCrit, ctx)
 }

--- a/log/root.go
+++ b/log/root.go
@@ -35,6 +35,7 @@ func DaoFork(t time.Time, connInfoCtx []interface{}, support bool) {
 	ctx := []interface{}{
 		"support", support,
 	}
+	ctx = append(ctx, connInfoCtx...)
 	root.write(fmt.Sprintf("%.6f", float64(t.UnixNano())/1e9), LvlDaoFork, ctx)
 }
 

--- a/node/config.go
+++ b/node/config.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/prometheus/prometheus/util/flock"
 	"github.com/teamnsrg/go-ethereum/accounts"
 	"github.com/teamnsrg/go-ethereum/accounts/keystore"
 	"github.com/teamnsrg/go-ethereum/accounts/usbwallet"
@@ -48,6 +49,10 @@ const (
 // all registered services.
 type Config struct {
 	LogToFile bool `toml:",omitempty"`
+
+	// InstanceDirLock is set at the very beginning if LogToFile is enabled
+	// It prevents concurrent use of instance directory
+	InstanceDirLock flock.Releaser
 
 	// Name sets the instance name of the node. It must not contain the / character and is
 	// used in the devp2p node identifier. The instance name of geth is "geth". If no

--- a/node/config.go
+++ b/node/config.go
@@ -47,6 +47,8 @@ const (
 // P2P network layer of a protocol stack. These values can be further extended by
 // all registered services.
 type Config struct {
+	LogToFile bool `toml:",omitempty"`
+
 	// Name sets the instance name of the node. It must not contain the / character and is
 	// used in the devp2p node identifier. The instance name of geth is "geth". If no
 	// value is specified, the basename of the current executable is used.

--- a/node/errors.go
+++ b/node/errors.go
@@ -32,7 +32,7 @@ var (
 	datadirInUseErrnos = map[uint]bool{11: true, 32: true, 35: true}
 )
 
-func convertFileLockError(err error) error {
+func ConvertFileLockError(err error) error {
 	if errno, ok := err.(syscall.Errno); ok && datadirInUseErrnos[uint(errno)] {
 		return ErrDatadirUsed
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -187,7 +187,7 @@ func (n *Node) Start() error {
 		running.Protocols = append(running.Protocols, service.Protocols()...)
 	}
 	if err := running.Start(); err != nil {
-		return convertFileLockError(err)
+		return ConvertFileLockError(err)
 	}
 	// Start each of the services
 	started := []reflect.Type{}
@@ -221,6 +221,10 @@ func (n *Node) Start() error {
 }
 
 func (n *Node) openDataDir() error {
+	if n.config.LogToFile {
+		n.instanceDirLock = n.config.InstanceDirLock
+		return nil
+	}
 	if n.config.DataDir == "" {
 		return nil // ephemeral
 	}
@@ -233,7 +237,7 @@ func (n *Node) openDataDir() error {
 	// accidental use of the instance directory as a database.
 	release, _, err := flock.New(filepath.Join(instdir, "LOCK"))
 	if err != nil {
-		return convertFileLockError(err)
+		return ConvertFileLockError(err)
 	}
 	n.instanceDirLock = release
 	return nil

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -311,7 +311,7 @@ func (t *udp) findnode(toid NodeID, toaddr *net.UDPAddr, target NodeID) ([]*Node
 			nreceived++
 			n, err := t.nodeFromRPC(toaddr, rn)
 			if err != nil {
-				log.Trace("Invalid neighbor node received", "neighbor_ip", rn.IP, "sender_ip", toaddr, "err", err)
+				log.Trace("Invalid neighbor node received", "neighborIp", rn.IP, "senderIp", toaddr, "err", err)
 				continue
 			}
 			nodes = append(nodes, n)
@@ -487,7 +487,7 @@ func (t *udp) send(toaddr *net.UDPAddr, ptype byte, req packet, peer NodeID) err
 		"id", peer.String(),
 		"addr", toaddr.String(),
 	}
-	log.Proto(currentTime, connInfoCtx, ">>"+req.name(), len(packet), req, err)
+	log.RLPXTx(currentTime, connInfoCtx, ">>"+req.name(), len(packet), req, err)
 	return err
 }
 
@@ -546,7 +546,7 @@ func (t *udp) handlePacket(from *net.UDPAddr, buf []byte) error {
 		"id", fromID.String(),
 		"addr", from.String(),
 	}
-	log.Proto(currentTime, connInfoCtx, "<<"+packet.name(), len(buf), packet, err)
+	log.RLPXRx(currentTime, connInfoCtx, "<<"+packet.name(), len(buf), packet, err)
 	err = packet.handle(t, from, fromID, hash)
 	return err
 }

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -482,7 +482,12 @@ func (t *udp) send(toaddr *net.UDPAddr, ptype byte, req packet, peer NodeID) err
 		return err
 	}
 	_, err = t.conn.WriteToUDP(packet, toaddr)
-	log.Proto(">>"+req.name(), "to", toaddr.String(), "size", len(packet), "err", err, "obj", req, "peer", peer)
+	currentTime := time.Now()
+	connInfoCtx := []interface{}{
+		"id", peer.String(),
+		"addr", toaddr.String(),
+	}
+	log.Proto(currentTime, connInfoCtx, ">>"+req.name(), len(packet), req, err)
 	return err
 }
 
@@ -536,8 +541,13 @@ func (t *udp) handlePacket(from *net.UDPAddr, buf []byte) error {
 		log.Debug("Bad discv4 packet", "addr", from, "err", err)
 		return err
 	}
+	currentTime := time.Now()
+	connInfoCtx := []interface{}{
+		"id", fromID.String(),
+		"addr", from.String(),
+	}
+	log.Proto(currentTime, connInfoCtx, "<<"+packet.name(), len(buf), packet, err)
 	err = packet.handle(t, from, fromID, hash)
-	log.Proto("<<"+packet.name(), "from", from.String(), "size", len(buf), "err", err, "obj", packet, "peer", fromID)
 	return err
 }
 

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -147,14 +147,12 @@ func SendDEVp2p(w MsgWriter, msgcode uint64, data interface{}, connInfoCtx ...in
 	if !ok {
 		msgType = fmt.Sprintf("UNKNOWN_%v", msgcode)
 	}
-
 	obj := data
 	if dataArr, ok := data.([]interface{}); ok && len(dataArr) > 0 {
 		if d, ok := dataArr[0].(DiscReason); ok && msgcode == discMsg {
 			obj = discReasonToString[d]
 		}
 	}
-
 	log.DEVp2pTx(currentTime, connInfoCtx, ">>"+msgType, size, obj, err)
 	return err
 }

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -99,17 +99,6 @@ type MsgReadWriter interface {
 	MsgWriter
 }
 
-// Send writes an RLP-encoded message with the given code.
-// data should encode as an RLP list.
-func Send(w MsgWriter, msgcode uint64, data interface{}) error {
-	size, r, err := rlp.EncodeToReader(data)
-
-	if err != nil {
-		return err
-	}
-	return w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
-}
-
 var empty struct{}
 var dataExcludedMsgs = map[uint64]struct{}{
 	0x02: empty, //TxMsg

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -120,8 +120,8 @@ func SendEthSubproto(w MsgWriter, msgcode uint64, data interface{}, connInfoCtx 
 		return err
 	}
 
-	err = w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 	currentTime := time.Now()
+	err = w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 	msgType, ok := ethCodeToString[msgcode]
 	if !ok {
 		msgType = fmt.Sprintf("UNKNOWN_%v", msgcode)
@@ -141,8 +141,8 @@ func SendDEVp2p(w MsgWriter, msgcode uint64, data interface{}, connInfoCtx ...in
 		return err
 	}
 
-	err = w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 	currentTime := time.Now()
+	err = w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 	msgType, ok := devp2pCodeToString[msgcode]
 	if !ok {
 		msgType = fmt.Sprintf("UNKNOWN_%v", msgcode)

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -156,9 +156,9 @@ func SendDEVp2p(w MsgWriter, msgcode uint64, data interface{}, peers ...discover
 	}
 
 	obj := data
-	if d, ok := data.([]DiscReason); ok && msgcode == discMsg {
-		if len(d) > 0 {
-			obj = discReasonToString[d[0]]
+	if dataArr, ok := data.([]interface{}); ok && len(dataArr) > 0 {
+		if d, ok := dataArr[0].(DiscReason); ok && msgcode == discMsg {
+			obj = discReasonToString[d]
 		}
 	}
 	log.Proto(">>"+msgType, "obj", obj, "size", size, "peer", peer)

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -130,7 +130,7 @@ func SendEthSubproto(w MsgWriter, msgcode uint64, data interface{}, connInfoCtx 
 	if obj, ok = dataExcludedMsgs[msgcode]; ok {
 		obj = "<OMITTED>"
 	}
-	log.Proto(currentTime, connInfoCtx, ">>"+msgType, size, obj, err)
+	log.EthTx(currentTime, connInfoCtx, ">>"+msgType, size, obj, err)
 	return err
 }
 
@@ -155,7 +155,7 @@ func SendDEVp2p(w MsgWriter, msgcode uint64, data interface{}, connInfoCtx ...in
 		}
 	}
 
-	log.Proto(currentTime, connInfoCtx, ">>"+msgType, size, obj, err)
+	log.DEVp2pTx(currentTime, connInfoCtx, ">>"+msgType, size, obj, err)
 	return err
 }
 

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -127,7 +127,7 @@ func SendEthSubproto(w MsgWriter, msgcode uint64, data interface{}, connInfoCtx 
 		msgType = fmt.Sprintf("UNKNOWN_%v", msgcode)
 	}
 	obj := data
-	if obj, ok = dataExcludedMsgs[msgcode]; ok {
+	if _, ok := dataExcludedMsgs[msgcode]; ok {
 		obj = "<OMITTED>"
 	}
 	log.EthTx(currentTime, connInfoCtx, ">>"+msgType, size, obj, err)

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -168,14 +168,14 @@ func SendDEVp2p(w MsgWriter, msgcode uint64, data interface{}, peers ...discover
 // SendItems writes an RLP with the given code and data elements.
 // For a call such as:
 //
-//    SendItems(w, code, e1, e2, e3)
+//    SendItems(id, w, code, e1, e2, e3)
 //
 // the message payload will be an RLP list containing the items:
 //
 //    [e1, e2, e3]
 //
-func SendItems(w MsgWriter, msgcode uint64, elems ...interface{}) error {
-	return SendDEVp2p(w, msgcode, elems)
+func SendItems(id discover.NodeID, w MsgWriter, msgcode uint64, elems ...interface{}) error {
+	return SendDEVp2p(w, msgcode, elems, id)
 }
 
 // netWrapper wraps a MsgReadWriter with locks around

--- a/p2p/message_test.go
+++ b/p2p/message_test.go
@@ -30,8 +30,8 @@ import (
 func ExampleMsgPipe() {
 	rw1, rw2 := MsgPipe()
 	go func() {
-		Send(rw1, 8, [][]byte{{0, 0}})
-		Send(rw1, 5, [][]byte{{1, 1}})
+		SendDEVp2p(rw1, 8, [][]byte{{0, 0}})
+		SendDEVp2p(rw1, 5, [][]byte{{1, 1}})
 		rw1.Close()
 	}()
 

--- a/p2p/message_test.go
+++ b/p2p/message_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"github.com/teamnsrg/go-ethereum/p2p/discover"
 	"io"
 	"runtime"
 	"strings"
@@ -55,7 +56,7 @@ loop:
 		rw1, rw2 := MsgPipe()
 		done := make(chan struct{})
 		go func() {
-			if err := SendItems(rw1, 1); err == nil {
+			if err := SendItems(discover.NodeID{}, rw1, 1); err == nil {
 				t.Error("EncodeMsg returned nil error")
 			} else if err != ErrPipeClosed {
 				t.Errorf("EncodeMsg returned wrong error: got %v, want %v", err, ErrPipeClosed)

--- a/p2p/message_test.go
+++ b/p2p/message_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"github.com/teamnsrg/go-ethereum/p2p/discover"
 	"io"
 	"runtime"
 	"strings"
@@ -56,7 +55,7 @@ loop:
 		rw1, rw2 := MsgPipe()
 		done := make(chan struct{})
 		go func() {
-			if err := SendItems(discover.NodeID{}, rw1, 1); err == nil {
+			if err := SendItems(rw1, 1, []interface{}{}); err == nil {
 				t.Error("EncodeMsg returned nil error")
 			} else if err != ErrPipeClosed {
 				t.Errorf("EncodeMsg returned wrong error: got %v, want %v", err, ErrPipeClosed)

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -275,7 +275,7 @@ func (p *Peer) pingLoop() {
 	for {
 		select {
 		case <-ping.C:
-			if err := SendItems(p.ID(), p.rw, pingMsg, make([]interface{}, 0)); err != nil {
+			if err := SendItems(p.ID(), p.rw, pingMsg); err != nil {
 				p.protoErr <- err
 				return
 			}
@@ -308,7 +308,7 @@ func (p *Peer) handle(msg Msg) error {
 	case msg.Code == pingMsg:
 		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
 		msg.Discard()
-		go SendItems(p.ID(), p.rw, pongMsg, make([]interface{}, 0))
+		go SendItems(p.ID(), p.rw, pongMsg)
 	case msg.Code == pongMsg:
 		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
 		msg.Discard()

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -17,6 +17,7 @@
 package p2p
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -24,7 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"encoding/json"
 	"github.com/teamnsrg/go-ethereum/common"
 	"github.com/teamnsrg/go-ethereum/common/mclock"
 	"github.com/teamnsrg/go-ethereum/event"
@@ -148,6 +148,11 @@ type Peer struct {
 func NewPeer(id discover.NodeID, name string, caps []Cap) *Peer {
 	pipe, _ := net.Pipe()
 	conn := &conn{fd: pipe, transport: nil, id: id, caps: caps, name: name}
+	conn.connInfoCtx = []interface{}{
+		"id", conn.id.String(),
+		"addr", conn.fd.RemoteAddr().String(),
+		"conn", conn.flags.String(),
+	}
 	peer := newPeer(conn, nil)
 	close(peer.closed) // ensures Disconnect doesn't block
 	return peer
@@ -156,7 +161,7 @@ func NewPeer(id discover.NodeID, name string, caps []Cap) *Peer {
 func (phs *protoHandshake) GoString() string {
 	j, err := json.Marshal(phs)
 	if err != nil {
-		log.Crit(err.Error())
+		return "<" + err.Error() + ">"
 	}
 	return string(j)
 }
@@ -215,6 +220,10 @@ func newPeer(conn *conn, protocols []Protocol) *Peer {
 	return p
 }
 
+func (p *Peer) ConnInfoCtx() []interface{} {
+	return p.rw.connInfoCtx
+}
+
 func (p *Peer) Log() log.Logger {
 	return p.log
 }
@@ -263,7 +272,7 @@ loop:
 	}
 
 	close(p.closed)
-	p.rw.close(reason, p.ID())
+	p.rw.close(reason, p.ConnInfoCtx()...)
 	p.wg.Wait()
 	return remoteRequested, err
 }
@@ -275,7 +284,7 @@ func (p *Peer) pingLoop() {
 	for {
 		select {
 		case <-ping.C:
-			if err := SendItems(p.ID(), p.rw, pingMsg); err != nil {
+			if err := SendItems(p.rw, pingMsg, p.ConnInfoCtx()); err != nil {
 				p.protoErr <- err
 				return
 			}
@@ -304,34 +313,35 @@ func (p *Peer) readLoop(errc chan<- error) {
 
 func (p *Peer) handle(msg Msg) error {
 	var emptyMsgObj []interface{}
+	connInfoCtx := p.ConnInfoCtx()
 	switch {
 	case msg.Code == pingMsg:
-		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), emptyMsgObj, nil)
 		msg.Discard()
-		go SendItems(p.ID(), p.rw, pongMsg)
+		go SendItems(p.rw, pongMsg, connInfoCtx)
 	case msg.Code == pongMsg:
-		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), emptyMsgObj, nil)
 		msg.Discard()
 	case msg.Code == discMsg:
 		var reason [1]DiscReason
 		// This is the last message. We don't need to discard or
 		// check errors because, the connection will be closed after it.
-		rlp.Decode(msg.Payload, &reason)
-		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", discReasonToString[reason[0]], "size", int(msg.Size), "peer", p.ID())
+		err := rlp.Decode(msg.Payload, &reason)
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), discReasonToString[reason[0]], err)
 		return reason[0]
 	case msg.Code < baseProtocolLength:
 		// ignore other base protocol messages
-		if int(msg.Code) < len(devp2pCodeToString) {
-			log.Proto("<<UNEXPECTED_"+devp2pCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+		if msgType, ok := devp2pCodeToString[msg.Code]; ok {
+			log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+msgType, int(msg.Size), "<OMITTED>", nil)
 		} else {
-			log.Proto(fmt.Sprintf("<<UNEXPECTED_UNKNOWN_%v", msg.Code), "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+			log.Proto(msg.ReceivedAt, connInfoCtx, "<<UNKNOWN_"+msgType, int(msg.Size), "<OMITTED>", nil)
 		}
 		return msg.Discard()
 	default:
 		// it's a subprotocol message
 		proto, err := p.getProto(msg.Code)
 		if err != nil {
-			p.log.Proto(fmt.Sprintf("<<CODE_OUT_OF_RANGE_%v", msg.Code), "obj", "<OMITTED>", "size", int(msg.Size), "peer", p.ID())
+			log.Proto(msg.ReceivedAt, connInfoCtx, fmt.Sprintf("<<CODE_OUT_OF_RANGE_%v", msg.Code), int(msg.Size), "<OMITTED>", nil)
 			return fmt.Errorf("msg code out of range: %v", msg.Code)
 		}
 		select {
@@ -474,7 +484,7 @@ type PeerInfo struct {
 func (pi *PeerInfo) GoString() string {
 	j, err := json.Marshal(pi)
 	if err != nil {
-		log.Crit(err.Error())
+		return "<" + err.Error() + ">"
 	}
 	return string(j)
 }

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -53,7 +53,7 @@ const (
 	peersMsg     = 0x05
 )
 
-var devp2pCodeToString = [...]string{
+var devp2pCodeToString = map[uint64]string{
 	handshakeMsg: "DEVP2P_HELLO",
 	discMsg:      "DEVP2P_DISC",
 	pingMsg:      "DEVP2P_PING",
@@ -62,7 +62,7 @@ var devp2pCodeToString = [...]string{
 	peersMsg:     "DEVP2P_PEERS",
 }
 
-var ethCodeToString = [...]string{
+var ethCodeToString = map[uint64]string{
 	// Protocol messages belonging to eth/62
 	0x00: "ETH_STATUS",
 	0x01: "ETH_NEW_BLOCK_HASHES",

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -275,7 +275,7 @@ func (p *Peer) pingLoop() {
 	for {
 		select {
 		case <-ping.C:
-			if err := SendItems(p.rw, pingMsg, make([]interface{}, 0)); err != nil {
+			if err := SendItems(p.ID(), p.rw, pingMsg, make([]interface{}, 0)); err != nil {
 				p.protoErr <- err
 				return
 			}
@@ -308,7 +308,7 @@ func (p *Peer) handle(msg Msg) error {
 	case msg.Code == pingMsg:
 		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
 		msg.Discard()
-		go SendItems(p.rw, pongMsg, make([]interface{}, 0))
+		go SendItems(p.ID(), p.rw, pongMsg, make([]interface{}, 0))
 	case msg.Code == pongMsg:
 		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
 		msg.Discard()

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -316,32 +316,32 @@ func (p *Peer) handle(msg Msg) error {
 	connInfoCtx := p.ConnInfoCtx()
 	switch {
 	case msg.Code == pingMsg:
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), emptyMsgObj, nil)
+		log.DEVp2pRx(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), emptyMsgObj, nil)
 		msg.Discard()
 		go SendItems(p.rw, pongMsg, connInfoCtx)
 	case msg.Code == pongMsg:
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), emptyMsgObj, nil)
+		log.DEVp2pRx(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), emptyMsgObj, nil)
 		msg.Discard()
 	case msg.Code == discMsg:
 		var reason [1]DiscReason
 		// This is the last message. We don't need to discard or
 		// check errors because, the connection will be closed after it.
 		err := rlp.Decode(msg.Payload, &reason)
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), discReasonToString[reason[0]], err)
+		log.DEVp2pRx(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), discReasonToString[reason[0]], err)
 		return reason[0]
 	case msg.Code < baseProtocolLength:
-		// ignore other base protocol messages
 		if msgType, ok := devp2pCodeToString[msg.Code]; ok {
-			log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+msgType, int(msg.Size), "<OMITTED>", nil)
+			log.DEVp2pRx(msg.ReceivedAt, connInfoCtx, "<<"+msgType, int(msg.Size), "<OMITTED>", nil)
 		} else {
-			log.Proto(msg.ReceivedAt, connInfoCtx, "<<UNKNOWN_"+msgType, int(msg.Size), "<OMITTED>", nil)
+			log.DEVp2pRx(msg.ReceivedAt, connInfoCtx, "<<UNKNOWN_"+msgType, int(msg.Size), "<OMITTED>", nil)
 		}
+		// ignore other base protocol messages
 		return msg.Discard()
 	default:
 		// it's a subprotocol message
 		proto, err := p.getProto(msg.Code)
 		if err != nil {
-			log.Proto(msg.ReceivedAt, connInfoCtx, fmt.Sprintf("<<CODE_OUT_OF_RANGE_%v", msg.Code), int(msg.Size), "<OMITTED>", nil)
+			log.DEVp2pRx(msg.ReceivedAt, connInfoCtx, fmt.Sprintf("<<CODE_OUT_OF_RANGE_%v", msg.Code), int(msg.Size), "<OMITTED>", nil)
 			return fmt.Errorf("msg code out of range: %v", msg.Code)
 		}
 		select {

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -275,7 +275,7 @@ func (p *Peer) pingLoop() {
 	for {
 		select {
 		case <-ping.C:
-			if err := SendDEVp2p(p.rw, pingMsg, make([]interface{}, 0), p.ID()); err != nil {
+			if err := SendItems(p.rw, pingMsg, make([]interface{}, 0)); err != nil {
 				p.protoErr <- err
 				return
 			}
@@ -308,7 +308,7 @@ func (p *Peer) handle(msg Msg) error {
 	case msg.Code == pingMsg:
 		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
 		msg.Discard()
-		go SendDEVp2p(p.rw, pongMsg, make([]interface{}, 0), p.ID())
+		go SendItems(p.rw, pongMsg, make([]interface{}, 0))
 	case msg.Code == pongMsg:
 		p.log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", p.ID())
 		msg.Discard()

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -59,7 +59,7 @@ func testPeer(protos []Protocol) (func(), *conn, *Peer, <-chan error) {
 		errc <- err
 	}()
 
-	closer := func() { c2.close(errors.New("close func called"), peer.ID()) }
+	closer := func() { c2.close(errors.New("close func called")) }
 	return closer, c2, peer, errc
 }
 
@@ -103,10 +103,10 @@ func TestPeerProtoEncodeMsg(t *testing.T) {
 		Name:   "a",
 		Length: 2,
 		Run: func(peer *Peer, rw MsgReadWriter) error {
-			if err := SendItems(peer.ID(), rw, 2); err == nil {
+			if err := SendItems(rw, 2, []interface{}{}); err == nil {
 				t.Error("expected error for out-of-range msg code, got nil")
 			}
-			if err := SendItems(peer.ID(), rw, 1, "foo", "bar"); err != nil {
+			if err := SendItems(rw, 1, []interface{}{}, "foo", "bar"); err != nil {
 				t.Errorf("write error: %v", err)
 			}
 			return nil
@@ -121,9 +121,9 @@ func TestPeerProtoEncodeMsg(t *testing.T) {
 }
 
 func TestPeerPing(t *testing.T) {
-	closer, rw, p, _ := testPeer(nil)
+	closer, rw, _, _ := testPeer(nil)
 	defer closer()
-	if err := SendItems(p.ID(), rw, pingMsg); err != nil {
+	if err := SendItems(rw, pingMsg, []interface{}{}); err != nil {
 		t.Fatal(err)
 	}
 	if err := ExpectMsg(rw, pongMsg, nil); err != nil {
@@ -132,9 +132,9 @@ func TestPeerPing(t *testing.T) {
 }
 
 func TestPeerDisconnect(t *testing.T) {
-	closer, rw, p, disc := testPeer(nil)
+	closer, rw, _, disc := testPeer(nil)
 	defer closer()
-	if err := SendItems(p.ID(), rw, discMsg, DiscQuitting); err != nil {
+	if err := SendItems(rw, discMsg, []interface{}{}, DiscQuitting); err != nil {
 		t.Fatal(err)
 	}
 	select {
@@ -169,8 +169,8 @@ func TestPeerDisconnectRace(t *testing.T) {
 		})
 
 		// Simulate incoming messages.
-		go SendItems(p.ID(), rw, baseProtocolLength+1)
-		go SendItems(p.ID(), rw, baseProtocolLength+2)
+		go SendItems(rw, baseProtocolLength+1, []interface{}{})
+		go SendItems(rw, baseProtocolLength+2, []interface{}{})
 		// Close the network connection.
 		go closer()
 		// Make protocol "closereq" return.
@@ -183,7 +183,7 @@ func TestPeerDisconnectRace(t *testing.T) {
 		}
 		// In some cases, simulate remote requesting a disconnect.
 		if maybe() {
-			go SendItems(p.ID(), rw, discMsg, DiscQuitting)
+			go SendItems(rw, discMsg, []interface{}{}, DiscQuitting)
 		}
 
 		select {

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -84,9 +84,9 @@ func TestPeerProtoReadMsg(t *testing.T) {
 	closer, rw, _, errc := testPeer([]Protocol{proto})
 	defer closer()
 
-	Send(rw, baseProtocolLength+2, []uint{1})
-	Send(rw, baseProtocolLength+3, []uint{2})
-	Send(rw, baseProtocolLength+4, []uint{3})
+	SendDEVp2p(rw, baseProtocolLength+2, []uint{1})
+	SendDEVp2p(rw, baseProtocolLength+3, []uint{2})
+	SendDEVp2p(rw, baseProtocolLength+4, []uint{3})
 
 	select {
 	case err := <-errc:

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -110,7 +110,7 @@ func (t *rlpx) close(err error, peer discover.NodeID) {
 	if t.rw != nil {
 		if r, ok := err.(DiscReason); ok && r != DiscNetworkError {
 			t.fd.SetWriteDeadline(time.Now().Add(discWriteTimeout))
-			SendDEVp2p(t.rw, discMsg, r, peer)
+			SendItems(t.rw, discMsg, r)
 		}
 	}
 	t.fd.Close()

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -103,14 +103,14 @@ func (t *rlpx) WriteMsg(msg Msg) error {
 	return t.rw.WriteMsg(msg)
 }
 
-func (t *rlpx) close(err error, id discover.NodeID) {
+func (t *rlpx) close(err error, connInfoCtx ...interface{}) {
 	t.wmu.Lock()
 	defer t.wmu.Unlock()
 	// Tell the remote end why we're disconnecting if possible.
 	if t.rw != nil {
 		if r, ok := err.(DiscReason); ok && r != DiscNetworkError {
 			t.fd.SetWriteDeadline(time.Now().Add(discWriteTimeout))
-			SendItems(id, t.rw, discMsg, r)
+			SendItems(t.rw, discMsg, connInfoCtx, r)
 		}
 	}
 	t.fd.Close()
@@ -120,14 +120,14 @@ func (t *rlpx) close(err error, id discover.NodeID) {
 // messages. the protocol handshake is the first authenticated message
 // and also verifies whether the encryption handshake 'worked' and the
 // remote side actually provided the right public key.
-func (t *rlpx) doProtoHandshake(our *protoHandshake, id discover.NodeID) (their *protoHandshake, err error) {
+func (t *rlpx) doProtoHandshake(our *protoHandshake, connInfoCtx ...interface{}) (their *protoHandshake, err error) {
 	// Writing our handshake happens concurrently, we prefer
 	// returning the handshake read error. If the remote side
 	// disconnects us early with a valid reason, we should return it
 	// as the error so it can be tracked elsewhere.
 	werr := make(chan error, 1)
-	go func() { werr <- SendDEVp2p(t.rw, handshakeMsg, our, id) }()
-	if their, err = readProtocolHandshake(t.rw, id); err != nil {
+	go func() { werr <- SendDEVp2p(t.rw, handshakeMsg, our, connInfoCtx...) }()
+	if their, err = readProtocolHandshake(t.rw, our, connInfoCtx...); err != nil {
 		<-werr // make sure the write terminates too
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (t *rlpx) doProtoHandshake(our *protoHandshake, id discover.NodeID) (their 
 	return their, nil
 }
 
-func readProtocolHandshake(rw MsgReader, id discover.NodeID) (*protoHandshake, error) {
+func readProtocolHandshake(rw MsgReader, our *protoHandshake, connInfoCtx ...interface{}) (*protoHandshake, error) {
 	msg, err := rw.ReadMsg()
 	if err != nil {
 		return nil, err
@@ -155,25 +155,26 @@ func readProtocolHandshake(rw MsgReader, id discover.NodeID) (*protoHandshake, e
 		// back otherwise. Wrap it in a string instead.
 		var reason [1]DiscReason
 		rlp.Decode(msg.Payload, &reason)
-		log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", discReasonToString[reason[0]], "size", int(msg.Size), "peer", id)
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), discReasonToString[reason[0]], nil)
 		return nil, reason[0]
 	}
 	if msg.Code != handshakeMsg {
 		var emptyMsgObj []interface{}
-		if int(msg.Code) < len(devp2pCodeToString) {
-			log.Proto("<<UNEXPECTED_"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", id)
+		if msgType, ok := devp2pCodeToString[msg.Code]; ok {
+			log.Proto(msg.ReceivedAt, connInfoCtx, "<<UNEXPECTED_"+msgType, int(msg.Size), emptyMsgObj, nil)
 		} else {
-			log.Proto(fmt.Sprintf("<<UNEXPECTED_UNKNOWN_%v", msg.Code), "obj", "<OMITTED>", "size", int(msg.Size), "peer", id)
+			log.Proto(msg.ReceivedAt, connInfoCtx, fmt.Sprintf("<<UNEXPECTED_UNKNOWN_%v", msg.Code), int(msg.Size), "<OMITTED>", nil)
+
 		}
 		return nil, fmt.Errorf("expected handshake, got %x", msg.Code)
 	}
 	var hs protoHandshake
 	if err := msg.Decode(&hs); err != nil {
-		log.Proto("<<FAIL_"+devp2pCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", id)
+		log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+devp2pCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 		return nil, err
 	}
 
-	log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", &hs, "size", int(msg.Size), "peer", hs.ID)
+	log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), &hs, nil)
 
 	if (hs.ID == discover.NodeID{}) {
 		return nil, DiscInvalidIdentity

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -155,26 +155,26 @@ func readProtocolHandshake(rw MsgReader, our *protoHandshake, connInfoCtx ...int
 		// back otherwise. Wrap it in a string instead.
 		var reason [1]DiscReason
 		rlp.Decode(msg.Payload, &reason)
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), discReasonToString[reason[0]], nil)
+		log.DEVp2pRx(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), discReasonToString[reason[0]], nil)
 		return nil, reason[0]
 	}
 	if msg.Code != handshakeMsg {
 		var emptyMsgObj []interface{}
 		if msgType, ok := devp2pCodeToString[msg.Code]; ok {
-			log.Proto(msg.ReceivedAt, connInfoCtx, "<<UNEXPECTED_"+msgType, int(msg.Size), emptyMsgObj, nil)
+			log.DEVp2pRx(msg.ReceivedAt, connInfoCtx, "<<UNEXPECTED_"+msgType, int(msg.Size), emptyMsgObj, nil)
 		} else {
-			log.Proto(msg.ReceivedAt, connInfoCtx, fmt.Sprintf("<<UNEXPECTED_UNKNOWN_%v", msg.Code), int(msg.Size), "<OMITTED>", nil)
+			log.DEVp2pRx(msg.ReceivedAt, connInfoCtx, fmt.Sprintf("<<UNEXPECTED_UNKNOWN_%v", msg.Code), int(msg.Size), "<OMITTED>", nil)
 
 		}
 		return nil, fmt.Errorf("expected handshake, got %x", msg.Code)
 	}
 	var hs protoHandshake
 	if err := msg.Decode(&hs); err != nil {
-		log.Proto(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+devp2pCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
+		log.DEVp2pRx(msg.ReceivedAt, connInfoCtx, "<<FAIL_"+devp2pCodeToString[msg.Code], int(msg.Size), "<OMITTED>", nil)
 		return nil, err
 	}
 
-	log.Proto(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), &hs, nil)
+	log.DEVp2pRx(msg.ReceivedAt, connInfoCtx, "<<"+devp2pCodeToString[msg.Code], int(msg.Size), &hs, nil)
 
 	if (hs.ID == discover.NodeID{}) {
 		return nil, DiscInvalidIdentity

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -103,14 +103,14 @@ func (t *rlpx) WriteMsg(msg Msg) error {
 	return t.rw.WriteMsg(msg)
 }
 
-func (t *rlpx) close(err error, peer discover.NodeID) {
+func (t *rlpx) close(err error, id discover.NodeID) {
 	t.wmu.Lock()
 	defer t.wmu.Unlock()
 	// Tell the remote end why we're disconnecting if possible.
 	if t.rw != nil {
 		if r, ok := err.(DiscReason); ok && r != DiscNetworkError {
 			t.fd.SetWriteDeadline(time.Now().Add(discWriteTimeout))
-			SendItems(t.rw, discMsg, r)
+			SendItems(id, t.rw, discMsg, r)
 		}
 	}
 	t.fd.Close()
@@ -120,14 +120,14 @@ func (t *rlpx) close(err error, peer discover.NodeID) {
 // messages. the protocol handshake is the first authenticated message
 // and also verifies whether the encryption handshake 'worked' and the
 // remote side actually provided the right public key.
-func (t *rlpx) doProtoHandshake(our *protoHandshake, peer discover.NodeID) (their *protoHandshake, err error) {
+func (t *rlpx) doProtoHandshake(our *protoHandshake, id discover.NodeID) (their *protoHandshake, err error) {
 	// Writing our handshake happens concurrently, we prefer
 	// returning the handshake read error. If the remote side
 	// disconnects us early with a valid reason, we should return it
 	// as the error so it can be tracked elsewhere.
 	werr := make(chan error, 1)
-	go func() { werr <- SendDEVp2p(t.rw, handshakeMsg, our, peer) }()
-	if their, err = readProtocolHandshake(t.rw, peer); err != nil {
+	go func() { werr <- SendDEVp2p(t.rw, handshakeMsg, our, id) }()
+	if their, err = readProtocolHandshake(t.rw, id); err != nil {
 		<-werr // make sure the write terminates too
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (t *rlpx) doProtoHandshake(our *protoHandshake, peer discover.NodeID) (thei
 	return their, nil
 }
 
-func readProtocolHandshake(rw MsgReader, peer discover.NodeID) (*protoHandshake, error) {
+func readProtocolHandshake(rw MsgReader, id discover.NodeID) (*protoHandshake, error) {
 	msg, err := rw.ReadMsg()
 	if err != nil {
 		return nil, err
@@ -155,21 +155,21 @@ func readProtocolHandshake(rw MsgReader, peer discover.NodeID) (*protoHandshake,
 		// back otherwise. Wrap it in a string instead.
 		var reason [1]DiscReason
 		rlp.Decode(msg.Payload, &reason)
-		log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", discReasonToString[reason[0]], "size", int(msg.Size), "peer", peer)
+		log.Proto("<<"+devp2pCodeToString[msg.Code], "obj", discReasonToString[reason[0]], "size", int(msg.Size), "peer", id)
 		return nil, reason[0]
 	}
 	if msg.Code != handshakeMsg {
 		var emptyMsgObj []interface{}
 		if int(msg.Code) < len(devp2pCodeToString) {
-			log.Proto("<<UNEXPECTED_"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", peer)
+			log.Proto("<<UNEXPECTED_"+devp2pCodeToString[msg.Code], "obj", emptyMsgObj, "size", int(msg.Size), "peer", id)
 		} else {
-			log.Proto(fmt.Sprintf("<<UNEXPECTED_UNKNOWN_%v", msg.Code), "obj", "<OMITTED>", "size", int(msg.Size), "peer", peer)
+			log.Proto(fmt.Sprintf("<<UNEXPECTED_UNKNOWN_%v", msg.Code), "obj", "<OMITTED>", "size", int(msg.Size), "peer", id)
 		}
 		return nil, fmt.Errorf("expected handshake, got %x", msg.Code)
 	}
 	var hs protoHandshake
 	if err := msg.Decode(&hs); err != nil {
-		log.Proto("<<FAIL_"+devp2pCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", peer)
+		log.Proto("<<FAIL_"+devp2pCodeToString[msg.Code], "obj", "<OMITTED>", "size", int(msg.Size), "peer", id)
 		return nil, err
 	}
 

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -145,6 +145,7 @@ func readProtocolHandshake(rw MsgReader, our *protoHandshake, connInfoCtx ...int
 	if err != nil {
 		return nil, err
 	}
+	msg.ReceivedAt = time.Now()
 	if msg.Size > baseProtocolMaxMsgSize {
 		return nil, fmt.Errorf("message too big")
 	}

--- a/p2p/rlpx_test.go
+++ b/p2p/rlpx_test.go
@@ -175,7 +175,7 @@ func TestProtocolHandshake(t *testing.T) {
 			return
 		}
 
-		phs, err := rlpx.doProtoHandshake(hs0, node1.ID)
+		phs, err := rlpx.doProtoHandshake(hs0)
 		if err != nil {
 			t.Errorf("dial side proto handshake error: %v", err)
 			return
@@ -185,7 +185,7 @@ func TestProtocolHandshake(t *testing.T) {
 			t.Errorf("dial side proto handshake mismatch:\ngot: %s\nwant: %s\n", spew.Sdump(phs), spew.Sdump(hs1))
 			return
 		}
-		rlpx.close(DiscQuitting, node1.ID)
+		rlpx.close(DiscQuitting)
 	}()
 	go func() {
 		defer wg.Done()
@@ -201,7 +201,7 @@ func TestProtocolHandshake(t *testing.T) {
 			return
 		}
 
-		phs, err := rlpx.doProtoHandshake(hs1, node0.ID)
+		phs, err := rlpx.doProtoHandshake(hs1)
 		if err != nil {
 			t.Errorf("listen side proto handshake error: %v", err)
 			return
@@ -220,6 +220,7 @@ func TestProtocolHandshake(t *testing.T) {
 }
 
 func TestProtocolHandshakeErrors(t *testing.T) {
+	our := &protoHandshake{Version: 3, Caps: []Cap{{"foo", 2}, {"bar", 3}}, Name: "quux"}
 	tests := []struct {
 		code uint64
 		msg  interface{}
@@ -255,7 +256,7 @@ func TestProtocolHandshakeErrors(t *testing.T) {
 	for i, test := range tests {
 		p1, p2 := MsgPipe()
 		go SendDEVp2p(p1, test.code, test.msg)
-		_, err := readProtocolHandshake(p2, discover.NodeID{})
+		_, err := readProtocolHandshake(p2, our)
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("test %d: error mismatch: got %q, want %q", i, err, test.err)
 		}

--- a/p2p/rlpx_test.go
+++ b/p2p/rlpx_test.go
@@ -220,7 +220,6 @@ func TestProtocolHandshake(t *testing.T) {
 }
 
 func TestProtocolHandshakeErrors(t *testing.T) {
-	our := &protoHandshake{Version: 3, Caps: []Cap{{"foo", 2}, {"bar", 3}}, Name: "quux"}
 	tests := []struct {
 		code uint64
 		msg  interface{}
@@ -255,8 +254,8 @@ func TestProtocolHandshakeErrors(t *testing.T) {
 
 	for i, test := range tests {
 		p1, p2 := MsgPipe()
-		go Send(p1, test.code, test.msg)
-		_, err := readProtocolHandshake(p2, our)
+		go SendDEVp2p(p1, test.code, test.msg)
+		_, err := readProtocolHandshake(p2, discover.NodeID{})
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("test %d: error mismatch: got %q, want %q", i, err, test.err)
 		}
@@ -281,7 +280,7 @@ ba628a4ba590cb43f7848f41c4382885
 `)
 
 	// Check WriteMsg. This puts a message into the buffer.
-	if err := Send(rw, 8, []uint{1, 2, 3, 4}); err != nil {
+	if err := SendDEVp2p(rw, 8, []uint{1, 2, 3, 4}); err != nil {
 		t.Fatalf("WriteMsg error: %v", err)
 	}
 	written := buf.Bytes()
@@ -353,7 +352,7 @@ func TestRLPXFrameRW(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		// write message into conn buffer
 		wmsg := []interface{}{"foo", "bar", strings.Repeat("test", i)}
-		err := Send(rw1, uint64(i), wmsg)
+		err := SendDEVp2p(rw1, uint64(i), wmsg)
 		if err != nil {
 			t.Fatalf("WriteMsg error (i=%d): %v", i, err)
 		}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -206,7 +206,7 @@ type conn struct {
 type transport interface {
 	// The two handshakes.
 	doEncHandshake(prv *ecdsa.PrivateKey, dialDest *discover.Node) (discover.NodeID, error)
-	doProtoHandshake(our *protoHandshake, peer discover.NodeID) (*protoHandshake, error)
+	doProtoHandshake(our *protoHandshake, id discover.NodeID) (*protoHandshake, error)
 	// The MsgReadWriter can only be used after the encryption
 	// handshake has completed. The code uses conn.id to track this
 	// by setting it to a non-nil value after the encryption handshake.
@@ -214,7 +214,7 @@ type transport interface {
 	// transports must provide Close because we use MsgPipe in some of
 	// the tests. Closing the actual network connection doesn't do
 	// anything in those tests because NsgPipe doesn't use it.
-	close(err error, peer discover.NodeID)
+	close(err error, id discover.NodeID)
 }
 
 func (c *conn) String() string {

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -56,11 +56,11 @@ func (c *testTransport) doEncHandshake(prv *ecdsa.PrivateKey, dialDest *discover
 	return c.id, nil
 }
 
-func (c *testTransport) doProtoHandshake(our *protoHandshake) (*protoHandshake, error) {
+func (c *testTransport) doProtoHandshake(our *protoHandshake, peer discover.NodeID) (*protoHandshake, error) {
 	return &protoHandshake{ID: c.id, Name: "test"}, nil
 }
 
-func (c *testTransport) close(err error) {
+func (c *testTransport) close(err error, peer discover.NodeID) {
 	c.rlpx.fd.Close()
 	c.closeErr = err
 }
@@ -460,14 +460,14 @@ func (c *setupTransport) doEncHandshake(prv *ecdsa.PrivateKey, dialDest *discove
 	c.calls += "doEncHandshake,"
 	return c.id, c.encHandshakeErr
 }
-func (c *setupTransport) doProtoHandshake(our *protoHandshake) (*protoHandshake, error) {
+func (c *setupTransport) doProtoHandshake(our *protoHandshake, peer discover.NodeID) (*protoHandshake, error) {
 	c.calls += "doProtoHandshake,"
 	if c.protoHandshakeErr != nil {
 		return nil, c.protoHandshakeErr
 	}
 	return c.phs, nil
 }
-func (c *setupTransport) close(err error) {
+func (c *setupTransport) close(err error, peer discover.NodeID) {
 	c.calls += "close,"
 	c.closeErr = err
 }

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -56,11 +56,11 @@ func (c *testTransport) doEncHandshake(prv *ecdsa.PrivateKey, dialDest *discover
 	return c.id, nil
 }
 
-func (c *testTransport) doProtoHandshake(our *protoHandshake, peer discover.NodeID) (*protoHandshake, error) {
+func (c *testTransport) doProtoHandshake(our *protoHandshake, connInfoCtx ...interface{}) (*protoHandshake, error) {
 	return &protoHandshake{ID: c.id, Name: "test"}, nil
 }
 
-func (c *testTransport) close(err error, peer discover.NodeID) {
+func (c *testTransport) close(err error, connInfoCtx ...interface{}) {
 	c.rlpx.fd.Close()
 	c.closeErr = err
 }
@@ -460,14 +460,14 @@ func (c *setupTransport) doEncHandshake(prv *ecdsa.PrivateKey, dialDest *discove
 	c.calls += "doEncHandshake,"
 	return c.id, c.encHandshakeErr
 }
-func (c *setupTransport) doProtoHandshake(our *protoHandshake, peer discover.NodeID) (*protoHandshake, error) {
+func (c *setupTransport) doProtoHandshake(our *protoHandshake, connInfoCtx ...interface{}) (*protoHandshake, error) {
 	c.calls += "doProtoHandshake,"
 	if c.protoHandshakeErr != nil {
 		return nil, c.protoHandshakeErr
 	}
 	return c.phs, nil
 }
-func (c *setupTransport) close(err error, peer discover.NodeID) {
+func (c *setupTransport) close(err error, connInfoCtx ...interface{}) {
 	c.calls += "close,"
 	c.closeErr = err
 }

--- a/p2p/simulations/examples/ping-pong.go
+++ b/p2p/simulations/examples/ping-pong.go
@@ -154,7 +154,7 @@ func (p *pingPongService) Run(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
 	go func() {
 		for range time.Tick(10 * time.Second) {
 			log.Info("sending ping")
-			if err := p2p.Send(rw, pingMsgCode, "PING"); err != nil {
+			if err := p2p.SendDEVp2p(rw, pingMsgCode, "PING"); err != nil {
 				errC <- err
 				return
 			}
@@ -176,7 +176,7 @@ func (p *pingPongService) Run(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
 			atomic.AddInt64(&p.received, 1)
 			if msg.Code == pingMsgCode {
 				log.Info("sending pong")
-				go p2p.Send(rw, pongMsgCode, "PONG")
+				go p2p.SendDEVp2p(rw, pongMsgCode, "PONG")
 			}
 		}
 	}()

--- a/p2p/simulations/http_test.go
+++ b/p2p/simulations/http_test.go
@@ -125,7 +125,7 @@ func (t *testService) Stop() error {
 // message with the given code
 func (t *testService) handshake(rw p2p.MsgReadWriter, code uint64) error {
 	errc := make(chan error, 2)
-	go func() { errc <- p2p.Send(rw, code, struct{}{}) }()
+	go func() { errc <- p2p.SendDEVp2p(rw, code, struct{}{}) }()
 	go func() { errc <- p2p.ExpectMsg(rw, code, struct{}{}) }()
 	for i := 0; i < 2; i++ {
 		if err := <-errc; err != nil {

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -22,11 +22,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/teamnsrg/go-ethereum/common"
 	"io"
 	"math/big"
 	"reflect"
 	"strings"
+
+	"github.com/teamnsrg/go-ethereum/common"
 )
 
 var (

--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -316,7 +316,7 @@ func (self *bzz) handleStatus() (err error) {
 		},
 	}
 
-	err = p2p.Send(self.rw, statusMsg, handshake)
+	err = p2p.SendDEVp2p(self.rw, statusMsg, handshake)
 	if err != nil {
 		return err
 	}
@@ -502,7 +502,7 @@ func (self *bzz) send(msg uint64, data interface{}) error {
 		return fmt.Errorf("network write blocked")
 	}
 	log.Trace(fmt.Sprintf("-> %v: %v (%T) to %v", msg, data, data, self))
-	err := p2p.Send(self.rw, msg, data)
+	err := p2p.SendDEVp2p(self.rw, msg, data)
 	if err != nil {
 		self.Drop()
 	}


### PR DESCRIPTION
- [x] send function bug fixes
  - The Send function is removed to avoid confusion. All codes, including tests, should use either SendDEVp2p or SendEthSubProto.
  - Any part of p2p package that previously used `Send` now use `SendDEVp2p`
  - Any part of eth package that previously used `Send` now use `SendEthSubproto`
  - Any part of all other packages that previously used `Send` now use `SendDEVp2p` (as logging is the only difference between the two).
  - `SendItems` should call `SendDEVp2p`. It is used by only p2p. Anywhere that previously used `SendItems` should continue to use it, not the other functions.
- [x] bring all original log messages back
- [x] include peer specific info (id, address, connection type) in every custom log message
  - [x] pass additional information to the send functions
- [x] log to file(s) at `datadir/geth-case-study/logs`. if not set, no logs are written to files, and only the ones with `log-level <= verbosity` are sent to `stderr`
  - `geth-case-study.log`: all log messages with `log-level <= verbosity` go here.
  - `rlpx-received.log`: `RLPXRX` - log level 6
  - `rlpx-sent.log`: `RLPXTX` - log level 7
  - `devp2p-received.log`: `DEVP2PRX` - log level 8
  - `devp2p-sent.log`: `DEVP2PTX` - log level 9
  - `eth-received.log`: `ETHRX` - log level 10
  - `eth-sent.log`: `ETHTX` - log level 11
  - `daofork.log`: `DAOFORK` - log level 12
- [x] add logrotate
  - use case: re-open/create the log files, after `logrotate` occurred (eg log filenames changed).
  - ex) `geth --exec 'admin.logrotate()' attach [/path/to/ipc]`

Log message formats:

- Prefix for all messages (both default and ours):
  `loglevel`|`log timestamp in unix time`
- Dao fork messages:
  `prefix`|`received timestamp`|`support=bool`|`id=nodeid`|`addr=ip:port`|`conn=connection type`
- All other custom messages:
  `prefix`|`sent/received timestamp`|`message type`|`size=int`|`data=...`|`err=...`|`id=nodeid`|`addr=ip:port`[|`conn=connection type`]
  - `RLPX` messages don't have `conn`