### PR TITLE
node-finder dial logic change

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -101,7 +101,7 @@ func main() {
 			utils.Fatalf("%v", err)
 		}
 	} else {
-		if _, err := discover.ListenUDP(nodeKey, *listenAddr, natm, "", restrictList, nil, nil); err != nil {
+		if _, _, err := discover.ListenUDP(nodeKey, *listenAddr, natm, "", restrictList, nil, nil); err != nil {
 			utils.Fatalf("%v", err)
 		}
 	}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -243,6 +243,7 @@ func init() {
 					log.LvlMatchFilterFileHandler(log.LvlMessageRx, logdir),
 					log.LvlMatchFilterFileHandler(log.LvlMessageTx, logdir),
 					log.LvlMatchFilterFileHandler(log.LvlNeighbors, logdir),
+					log.LvlMatchFilterFileHandler(log.LvlTask, logdir),
 					log.LvlMatchFilterFileHandler(log.LvlHello, logdir),
 					log.LvlMatchFilterFileHandler(log.LvlDiscProto, logdir),
 					log.LvlMatchFilterFileHandler(log.LvlDiscPeer, logdir),

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -244,6 +244,7 @@ func init() {
 					log.LvlMatchFilterFileHandler(log.LvlMessageTx, logdir),
 					log.LvlMatchFilterFileHandler(log.LvlNeighbors, logdir),
 					log.LvlMatchFilterFileHandler(log.LvlTask, logdir),
+					log.LvlMatchFilterFileHandler(log.LvlPeer, logdir),
 					log.LvlMatchFilterFileHandler(log.LvlHello, logdir),
 					log.LvlMatchFilterFileHandler(log.LvlDiscProto, logdir),
 					log.LvlMatchFilterFileHandler(log.LvlDiscPeer, logdir),

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -60,6 +60,7 @@ var (
 		utils.MaxNumFileFlag,
 		utils.BlacklistFlag,
 		utils.DialFreqFlag,
+		utils.DialCheckFreqFlag,
 		utils.PushFreqFlag,
 		utils.MySQLFlag,
 		utils.BackupSQLFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -72,6 +72,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.MaxNumFileFlag,
 			utils.BlacklistFlag,
 			utils.DialFreqFlag,
+			utils.DialCheckFreqFlag,
 			utils.PushFreqFlag,
 			utils.MySQLFlag,
 			utils.BackupSQLFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -132,6 +132,11 @@ var (
 		Usage: "Frequency of re-dialing static nodes (in seconds)",
 		Value: 30,
 	}
+	DialCheckFreqFlag = cli.IntFlag{
+		Name:  "dialcheckfreq",
+		Usage: "Frequency of checking static nodes ready for redial (in seconds)",
+		Value: 15,
+	}
 	PushFreqFlag = cli.IntFlag{
 		Name:  "pushfreq",
 		Usage: "Frequency of pushing updates to MySQL database (in seconds)",
@@ -830,6 +835,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 
 	if ctx.GlobalIsSet(DialFreqFlag.Name) {
 		cfg.DialFreq = ctx.GlobalInt(DialFreqFlag.Name)
+	}
+	if ctx.GlobalIsSet(DialCheckFreqFlag.Name) {
+		cfg.DialCheckFreq = ctx.GlobalInt(DialCheckFreqFlag.Name)
 	}
 	if ctx.GlobalIsSet(PushFreqFlag.Name) {
 		cfg.PushFreq = ctx.GlobalInt(PushFreqFlag.Name)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -149,6 +149,7 @@ func (pm *ProtocolManager) removePeer(id string) {
 	if peer == nil {
 		return
 	}
+	log.Peer("REMOVE|ETHEREUM", peer.ConnInfoCtx(), peer.Rtt(), peer.Duration())
 	log.Debug("Removing Ethereum peer", "id", id)
 
 	// Unregister the peer from the Ethereum peer set

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -23,11 +23,12 @@ import (
 	"sync"
 	"time"
 
+	"gopkg.in/fatih/set.v0"
+
 	"github.com/teamnsrg/go-ethereum/common"
 	"github.com/teamnsrg/go-ethereum/core/types"
 	"github.com/teamnsrg/go-ethereum/log"
 	"github.com/teamnsrg/go-ethereum/p2p"
-	"gopkg.in/fatih/set.v0"
 )
 
 var (
@@ -245,6 +246,7 @@ func (p *peer) readStatus(network uint64, statusWrapper *statusDataWrapper, gene
 	statusWrapper.Status = &status
 	statusWrapper.PeerRtt = msg.PeerRtt
 	statusWrapper.PeerDuration = msg.PeerDuration
+	log.Peer("ADD|ETHEREUM", p.ConnInfoCtx(), msg.PeerRtt, msg.PeerDuration)
 
 	if status.GenesisBlock != genesis {
 		statusWrapper.ErrorCode = ErrGenesisBlockMismatch
@@ -258,6 +260,7 @@ func (p *peer) readStatus(network uint64, statusWrapper *statusDataWrapper, gene
 		statusWrapper.ErrorCode = ErrProtocolVersionMismatch
 		return errResp(ErrProtocolVersionMismatch, "%d (!= %d)", status.ProtocolVersion, p.version)
 	}
+	log.Peer("ADD|MAINNET", p.ConnInfoCtx(), msg.PeerRtt, msg.PeerDuration)
 	return nil
 }
 

--- a/eth/sql_stmt.go
+++ b/eth/sql_stmt.go
@@ -1,11 +1,25 @@
 package eth
 
 import (
+	"fmt"
+
 	"github.com/teamnsrg/go-ethereum/p2p"
 	"github.com/teamnsrg/go-ethereum/p2p/discover"
 )
 
-func (pm *ProtocolManager) queueNodeEthInfo(id discover.NodeID, newInfo *p2p.Info, newStatus bool) {
+func (pm *ProtocolManager) queueNodeEthInfo(id discover.NodeID, newInfo *p2p.Info, newStatus bool) error {
+	if newInfo.FirstReceivedTd == nil {
+		return fmt.Errorf("FirstReceivedTd == nil")
+	}
+	if newInfo.LastReceivedTd == nil {
+		return fmt.Errorf("LastReceivedTd == nil")
+	}
+	if newInfo.FirstStatusAt == nil {
+		return fmt.Errorf("FirstStatusAt == nil")
+	}
+	if newInfo.LastStatusAt == nil {
+		return fmt.Errorf("LastStatusAt == nil")
+	}
 	pm.ethInfoChan <- []interface{}{
 		id.String(), newInfo.IP, newInfo.TCPPort, newInfo.RemotePort,
 		newInfo.P2PVersion, newInfo.ClientId, newInfo.Caps, newInfo.ListenPort,
@@ -13,6 +27,7 @@ func (pm *ProtocolManager) queueNodeEthInfo(id discover.NodeID, newInfo *p2p.Inf
 		newInfo.BestHash, newInfo.GenesisHash, newInfo.DAOForkSupport,
 		newInfo.FirstStatusAt.Float64(), newInfo.LastStatusAt.Float64(), boolToInt(newStatus),
 	}
+	return nil
 }
 
 func boolToInt(b bool) int {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -169,6 +169,11 @@ web3._extend({
 			params: 1,
 		}),
 		new web3._extend.Method({
+			name: 'setDialCheckFreq',
+			call: 'admin_setDialCheckFreq',
+			params: 1,
+		}),
+		new web3._extend.Method({
 			name: 'setPushFreq',
 			call: 'admin_setPushFreq',
 			params: 1,
@@ -199,6 +204,10 @@ web3._extend({
 		new web3._extend.Property({
 			name: 'dialFreq',
 			getter: 'admin_dialFreq'
+		}),
+		new web3._extend.Property({
+			name: 'dialCheckFreq',
+			getter: 'admin_dialCheckFreq'
 		}),
 		new web3._extend.Property({
 			name: 'pushFreq',

--- a/log/logger.go
+++ b/log/logger.go
@@ -26,6 +26,7 @@ const (
 	LvlMessageRx
 	LvlMessageTx
 	LvlNeighbors
+	LvlTask
 	LvlHello
 	LvlDiscProto
 	LvlDiscPeer
@@ -46,6 +47,8 @@ func (l Lvl) AlignedString() string {
 		return "DISCPROTO"
 	case LvlHello:
 		return "HELLO"
+	case LvlTask:
+		return "TASK"
 	case LvlNeighbors:
 		return "NEIGHBORS"
 	case LvlMessageTx:
@@ -84,6 +87,8 @@ func (l Lvl) String() string {
 		return "disc-proto"
 	case LvlHello:
 		return "hello"
+	case LvlTask:
+		return "task"
 	case LvlNeighbors:
 		return "neighbors"
 	case LvlMessageTx:
@@ -123,6 +128,8 @@ func LvlFromString(lvlString string) (Lvl, error) {
 		return LvlDiscProto, nil
 	case "hello":
 		return LvlHello, nil
+	case "task":
+		return LvlTask, nil
 	case "neighbors":
 		return LvlNeighbors, nil
 	case "message-sent", "message-tx", "msg-tx":
@@ -186,6 +193,7 @@ type Logger interface {
 	DiscProto(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, discReason string)
 	Hello(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, helloStr string)
 	Neighbors(t time.Time, ctx []interface{})
+	Task(msg string, taskInfoCtx []interface{})
 	MessageTx(t time.Time, msgType string, size int, connInfoCtx []interface{}, err error)
 	MessageRx(t time.Time, msgType string, size int, connInfoCtx []interface{}, err error)
 	Sql(msg string, ctx ...interface{})
@@ -295,6 +303,10 @@ func (l *logger) Hello(t time.Time, connInfoCtx []interface{}, rtt float64, dura
 	}
 	ctx = append(connInfoCtx, ctx...)
 	l.writeTime(LvlHello, t, ctx)
+}
+
+func (l *logger) Task(msg string, taskInfoCtx []interface{}) {
+	l.write(msg, LvlTask, taskInfoCtx)
 }
 
 func (l *logger) Neighbors(t time.Time, ctx []interface{}) {

--- a/log/logger.go
+++ b/log/logger.go
@@ -27,6 +27,7 @@ const (
 	LvlMessageTx
 	LvlNeighbors
 	LvlTask
+	LvlPeer
 	LvlHello
 	LvlDiscProto
 	LvlDiscPeer
@@ -47,6 +48,8 @@ func (l Lvl) AlignedString() string {
 		return "DISCPROTO"
 	case LvlHello:
 		return "HELLO"
+	case LvlPeer:
+		return "PEER"
 	case LvlTask:
 		return "TASK"
 	case LvlNeighbors:
@@ -87,6 +90,8 @@ func (l Lvl) String() string {
 		return "disc-proto"
 	case LvlHello:
 		return "hello"
+	case LvlPeer:
+		return "peer"
 	case LvlTask:
 		return "task"
 	case LvlNeighbors:
@@ -128,6 +133,8 @@ func LvlFromString(lvlString string) (Lvl, error) {
 		return LvlDiscProto, nil
 	case "hello":
 		return LvlHello, nil
+	case "peer":
+		return LvlPeer, nil
 	case "task":
 		return LvlTask, nil
 	case "neighbors":
@@ -192,8 +199,9 @@ type Logger interface {
 	DiscPeer(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, discReason string)
 	DiscProto(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, discReason string)
 	Hello(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, helloStr string)
-	Neighbors(t time.Time, ctx []interface{})
+	Peer(msg string, connInfoCtx []interface{}, rtt float64, duration float64)
 	Task(msg string, taskInfoCtx []interface{})
+	Neighbors(t time.Time, ctx []interface{})
 	MessageTx(t time.Time, msgType string, size int, connInfoCtx []interface{}, err error)
 	MessageRx(t time.Time, msgType string, size int, connInfoCtx []interface{}, err error)
 	Sql(msg string, ctx ...interface{})
@@ -303,6 +311,15 @@ func (l *logger) Hello(t time.Time, connInfoCtx []interface{}, rtt float64, dura
 	}
 	ctx = append(connInfoCtx, ctx...)
 	l.writeTime(LvlHello, t, ctx)
+}
+
+func (l *logger) Peer(msg string, connInfoCtx []interface{}, rtt float64, duration float64) {
+	ctx := []interface{}{
+		"rtt", rtt,
+		"duration", duration,
+	}
+	ctx = append(connInfoCtx, ctx...)
+	l.write(msg, LvlPeer, ctx)
 }
 
 func (l *logger) Task(msg string, taskInfoCtx []interface{}) {

--- a/log/root.go
+++ b/log/root.go
@@ -81,6 +81,15 @@ func Hello(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64
 	root.writeTime(LvlHello, t, ctx)
 }
 
+func Peer(msg string, connInfoCtx []interface{}, rtt float64, duration float64) {
+	ctx := []interface{}{
+		"rtt", rtt,
+		"duration", duration,
+	}
+	ctx = append(connInfoCtx, ctx...)
+	root.write(msg, LvlPeer, ctx)
+}
+
 func Task(msg string, taskInfoCtx []interface{}) {
 	root.write(msg, LvlTask, taskInfoCtx)
 }

--- a/log/root.go
+++ b/log/root.go
@@ -81,6 +81,10 @@ func Hello(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64
 	root.writeTime(LvlHello, t, ctx)
 }
 
+func Task(msg string, taskInfoCtx []interface{}) {
+	root.write(msg, LvlTask, taskInfoCtx)
+}
+
 func Neighbors(t time.Time, connInfoCtx []interface{}, neighbor interface{}) {
 	ctx := []interface{}{
 		"neighbor", neighbor,

--- a/node/api.go
+++ b/node/api.go
@@ -61,6 +61,7 @@ func (api *PrivateAdminAPI) Logrotate() error {
 			log.LvlMatchFilterFileHandler(log.LvlMessageRx, logdir),
 			log.LvlMatchFilterFileHandler(log.LvlMessageTx, logdir),
 			log.LvlMatchFilterFileHandler(log.LvlNeighbors, logdir),
+			log.LvlMatchFilterFileHandler(log.LvlTask, logdir),
 			log.LvlMatchFilterFileHandler(log.LvlHello, logdir),
 			log.LvlMatchFilterFileHandler(log.LvlDiscProto, logdir),
 			log.LvlMatchFilterFileHandler(log.LvlDiscPeer, logdir),

--- a/node/api.go
+++ b/node/api.go
@@ -108,7 +108,7 @@ func (api *PrivateAdminAPI) Blacklist() (interface{}, error) {
 }
 
 func (api *PrivateAdminAPI) AddBlacklist(cidrs string) error {
-	return api.node.Server().SetBlacklist(cidrs)
+	return api.node.Server().AddBlacklist(cidrs)
 }
 
 // AddPeer requests connecting to a remote node, and also maintaining the new

--- a/node/api.go
+++ b/node/api.go
@@ -80,6 +80,15 @@ func (api *PrivateAdminAPI) SetDialFreq(dialFreq int) error {
 	return nil
 }
 
+func (api *PrivateAdminAPI) DialCheckFreq() (int, error) {
+	return api.node.Server().DialCheckFreq, nil
+}
+
+func (api *PrivateAdminAPI) SetDialCheckFreq(dialCheckFreq int) error {
+	api.node.Server().SetDialCheckFreq(dialCheckFreq)
+	return nil
+}
+
 func (api *PrivateAdminAPI) PushFreq() (int, error) {
 	return api.node.Server().PushFreq, nil
 }

--- a/node/api.go
+++ b/node/api.go
@@ -62,6 +62,7 @@ func (api *PrivateAdminAPI) Logrotate() error {
 			log.LvlMatchFilterFileHandler(log.LvlMessageTx, logdir),
 			log.LvlMatchFilterFileHandler(log.LvlNeighbors, logdir),
 			log.LvlMatchFilterFileHandler(log.LvlTask, logdir),
+			log.LvlMatchFilterFileHandler(log.LvlPeer, logdir),
 			log.LvlMatchFilterFileHandler(log.LvlHello, logdir),
 			log.LvlMatchFilterFileHandler(log.LvlDiscProto, logdir),
 			log.LvlMatchFilterFileHandler(log.LvlDiscPeer, logdir),

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -48,6 +48,7 @@ var DefaultConfig = Config{
 		MaxDial:         16,
 		NoMaxPeers:      true, // node-finder never limits number of peers
 		DialFreq:        30,
+		DialCheckFreq:   15,
 		PushFreq:        1,
 		MySQLName:       "",
 		BackupSQL:       false,

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -35,10 +35,6 @@ const (
 	// once every few seconds.
 	lookupInterval = 4 * time.Second
 
-	// If no peers are found for this amount of time, the initial bootnodes are
-	// attempted to be connected.
-	fallbackInterval = 20 * time.Second
-
 	// Endpoint resolution is throttled with bounded backoff.
 	initialResolveDelay = 60 * time.Second
 	maxResolveDelay     = time.Hour

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -77,7 +77,11 @@ func runDialTest(t *testing.T, test dialtest) {
 			}
 		} else {
 			expected = round.new
-			result = test.init.newTasks(running, pm(round.peers), vtime)
+			var needDiscoverTask bool
+			result, needDiscoverTask = test.init.newTasks(running, pm(round.peers), vtime)
+			if needDiscoverTask {
+				result = append(result, &discoverTask{})
+			}
 			// we don't need dial context for test cases
 			for _, t := range result {
 				if r, ok := t.(*dialTask); ok {

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -70,23 +70,12 @@ func runDialTest(t *testing.T, test dialtest) {
 		if round.newStatic != nil {
 			expected = round.newStatic
 			result = test.init.newRedialTasks(pm(round.peers), vtime)
-			// we don't need dial context for test cases
-			for _, t := range result {
-				r := t.(*dialTask)
-				r.ctx, r.cancel = nil, nil
-			}
 		} else {
 			expected = round.new
 			var needDiscoverTask bool
 			result, needDiscoverTask = test.init.newTasks(running, pm(round.peers), vtime)
 			if needDiscoverTask {
 				result = append(result, &discoverTask{})
-			}
-			// we don't need dial context for test cases
-			for _, t := range result {
-				if r, ok := t.(*dialTask); ok {
-					r.ctx, r.cancel = nil, nil
-				}
 			}
 		}
 		if !sametasks(result, expected) {
@@ -539,7 +528,6 @@ func TestDialResolve(t *testing.T) {
 	dest := discover.NewNode(uintID(1), nil, 0, 0)
 	state.addStatic(dest)
 	s := state.static[dest.ID]
-	s.ctx, s.cancel = nil, nil // we don't need dial context for test cases
 	tasks := state.newRedialTasks(nil, time.Time{})
 	if !reflect.DeepEqual(tasks, []task{&dialTask{flags: staticDialedConn, dest: dest}}) {
 		t.Fatalf("expected dial task, got %#v", tasks)

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -527,16 +527,12 @@ func TestDialResolve(t *testing.T) {
 	// Check that the task is generated with an incomplete ID.
 	dest := discover.NewNode(uintID(1), nil, 0, 0)
 	state.addStatic(dest)
-	s := state.static[dest.ID]
 	tasks := state.newRedialTasks(nil, time.Time{})
 	if !reflect.DeepEqual(tasks, []task{&dialTask{flags: staticDialedConn, dest: dest}}) {
 		t.Fatalf("expected dial task, got %#v", tasks)
 	}
 
 	// Now run the task, it should resolve the ID once.
-	// node-finder does not resolve addresses of staticDialedConns
-	// manually change it to dynDialedConn to force resolve
-	s.flags = dynDialedConn
 	config := Config{Dialer: TCPDialer{&net.Dialer{Deadline: time.Now().Add(-5 * time.Minute)}}}
 	srv := &Server{ntab: table, Config: config}
 	tasks[0].Do(srv)

--- a/p2p/netutil/net.go
+++ b/p2p/netutil/net.go
@@ -128,13 +128,18 @@ func (l *Netlist) Add(cidr string) {
 	*l = append(*l, *n)
 }
 
-func (l *Netlist) AddNonDuplicate(cidr string) {
+func (l *Netlist) AddNonDuplicate(cidr string) error {
+	_, n, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return err
+	}
 	for _, val := range *l {
-		if cidr == val.String() {
-			return
+		if n.String() == val.String() {
+			return nil
 		}
 	}
-	l.Add(cidr)
+	*l = append(*l, *n)
+	return nil
 }
 
 // Contains reports whether the given IP is contained in the list.

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -206,7 +206,10 @@ func (srv *Server) getNodeAddress(c *conn, receivedAt *time.Time) (*Info, bool, 
 	// otherwise, remotePort is the listening port
 	if c.isInbound() {
 		if tcpPort == 0 {
-			newNode := srv.ntab.Resolve(c.id)
+			var newNode *discover.Node
+			if srv.ntab != nil {
+				newNode = srv.ntab.Resolve(c.id)
+			}
 			// if the node address is resolved, set the tcpPort
 			// otherwise, leave it as 0
 			if newNode != nil {

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -303,7 +303,9 @@ func (srv *Server) storeNodeP2PInfo(c *conn, msg *Msg, hs *protoHandshake) {
 	// update or add a new entry to node_p2p_info
 	if srv.p2pInfoChan != nil {
 		log.Sql("Queueing NodeP2PInfo", connInfoCtx...)
-		srv.queueNodeP2PInfo(id, newInfo)
+		if err := srv.queueNodeP2PInfo(id, newInfo); err != nil {
+			log.Sql("Failed to queue NodeP2PInfo", connInfoCtx...)
+		}
 	}
 }
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -156,6 +156,13 @@ func (p *Peer) Caps() []Cap {
 	return p.rw.caps
 }
 
+func (p *Peer) Rtt() float64 {
+	if p.rw.transport == nil {
+		return 0.0
+	}
+	return p.rw.Rtt()
+}
+
 func (p *Peer) Duration() float64 {
 	return monotime.Since(uint64(p.created)).Seconds()
 }
@@ -493,7 +500,7 @@ func (p *Peer) Info() *PeerInfo {
 		Protocols: make(map[string]interface{}),
 	}
 	if p.rw.transport != nil {
-		info.Rtt = p.rw.Rtt()
+		info.Rtt = p.Rtt()
 	}
 	info.Network.LocalAddress = p.LocalAddr().String()
 	info.Network.RemoteAddress = p.RemoteAddr().String()

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -593,7 +593,7 @@ func (srv *Server) run(dialstate dialer) {
 
 	// removes t from runningTasks
 	delTask := func(t task) {
-		log.Trace("Dial task done", "task", t)
+		log.Task("DONE", t.TaskInfoCtx())
 		dialstate.taskDone(t, time.Now())
 		switch t := t.(type) {
 		case *dialTask:
@@ -630,7 +630,7 @@ func (srv *Server) run(dialstate dialer) {
 		i := 0
 		for ; len(runningDynDial) < srv.MaxDial && i < len(ts); i++ {
 			t := ts[i]
-			log.Trace("New dial task", "task", t)
+			log.Task("NEW", t.TaskInfoCtx())
 			go func() { t.Do(srv); dyndialdone <- t }()
 			runningDynDial = append(runningDynDial, t)
 		}
@@ -646,7 +646,7 @@ func (srv *Server) run(dialstate dialer) {
 			queuedTasks = append(queuedTasks, startDynDialTasks(nt)...)
 			if needDiscoverTask {
 				t := &discoverTask{}
-				log.Trace("New dial task", "task", t)
+				log.Task("NEW", t.TaskInfoCtx())
 				go func() { t.Do(srv); discoverdone <- t }()
 				runningDiscover = append(runningDiscover, t)
 			}
@@ -655,7 +655,7 @@ func (srv *Server) run(dialstate dialer) {
 	scheduleRedialTasks := func() {
 		// Query dialer for new static tasks and start all
 		for _, t := range dialstate.newRedialTasks(peers, time.Now()) {
-			log.Trace("New dial task", "task", t)
+			log.Task("NEW", t.TaskInfoCtx())
 			go func(t task) { t.Do(srv); staticdialdone <- t }(t)
 			runningStaticDial = append(runningStaticDial, t)
 		}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -786,34 +786,6 @@ running:
 	if srv.p2pInfoChan != nil {
 		close(srv.p2pInfoChan)
 	}
-
-	// Wait for peers and tasks to shut down.
-	srv.loopWG.Add(2)
-	go func() {
-		defer srv.loopWG.Done()
-		n := len(peers)
-		for _, p := range peers {
-			<-srv.delpeer
-			n--
-			p.log.Trace("<-delpeer (spindown)", "remainingPeers", n)
-		}
-	}()
-	go func() {
-		defer srv.loopWG.Done()
-		runningTasks := append(runningStaticDial, runningDynDial...)
-		runningTasks = append(runningTasks, runningDiscover...)
-		n := len(runningTasks)
-		for _, t := range runningTasks {
-			switch t := t.(type) {
-			case *dialTask:
-				t.cancel()
-			case *discoverTask:
-				<-discoverdone
-			}
-			n--
-			log.Trace("<-taskdone (cancelled)", "task", t, "remainingTasks", n)
-		}
-	}()
 }
 
 func (srv *Server) protoHandshakeChecks(peers map[discover.NodeID]*Peer, c *conn) error {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -770,6 +770,7 @@ running:
 				}
 			}
 			d := common.PrettyDuration(mclock.Now() - pd.created)
+			log.Peer("REMOVE|DEVP2P", pd.ConnInfoCtx(), pd.Rtt(), time.Duration(d).Seconds())
 			pd.log.Debug("Removing p2p peer", "duration", d, "peers", len(peers)-1, "req", pd.requested, "err", pd.err)
 			delete(peers, pd.ID())
 		}
@@ -967,6 +968,7 @@ func (srv *Server) SetupConn(fd net.Conn, flags connFlag, dialDest *discover.Nod
 	}
 	// If the checks completed successfully, runPeer has now been
 	// launched by run.
+	log.Peer("ADD|DEVP2P", c.connInfoCtx, msg.PeerRtt, msg.PeerDuration)
 }
 
 func truncateName(s string) string {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -397,11 +397,11 @@ func (srv *Server) Stop() {
 		return
 	}
 	srv.running = false
+	close(srv.quit)
 	if srv.listener != nil {
 		// this unblocks listener Accept
 		srv.listener.Close()
 	}
-	close(srv.quit)
 	srv.loopWG.Wait()
 
 	srv.closeSql()

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -231,13 +231,11 @@ func TestServerTaskScheduling(t *testing.T) {
 	// The Server in this test isn't actually running
 	// because we're only interested in what run does.
 	srv := &Server{
-		Config:  Config{MaxPeers: 10},
+		Config:  Config{MaxPeers: 10, MaxDial: 16, DialCheckFreq: 15, PushFreq: 1},
 		quit:    make(chan struct{}),
 		ntab:    fakeTable{},
 		running: true,
 	}
-	srv.MaxDial = 16
-	srv.NoMaxPeers = false
 	srv.loopWG.Add(1)
 	go func() {
 		srv.run(tg)
@@ -282,6 +280,7 @@ func TestServerManyTasks(t *testing.T) {
 		start, end = 0, 0
 	)
 	srv.MaxDial = 16
+	srv.DialCheckFreq = 15
 	defer srv.Stop()
 	srv.loopWG.Add(1)
 	go srv.run(taskgen{

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -356,6 +356,10 @@ func (t *testTask) Do(srv *Server) {
 	t.called = true
 }
 
+func (t *testTask) TaskInfoCtx() []interface{} {
+	return nil
+}
+
 // This test checks that connections are disconnected
 // just after the encryption handshake when the server is
 // at capacity. Trusted connections should still be accepted.

--- a/p2p/simulations/adapters/inproc.go
+++ b/p2p/simulations/adapters/inproc.go
@@ -17,7 +17,6 @@
 package adapters
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -102,7 +101,7 @@ func (s *SimAdapter) NewNode(config *NodeConfig) (Node, error) {
 
 // Dial implements the p2p.NodeDialer interface by connecting to the node using
 // an in-memory net.Pipe connection
-func (s *SimAdapter) Dial(ctx context.Context, dest *discover.Node) (conn net.Conn, err error) {
+func (s *SimAdapter) Dial(dest *discover.Node) (conn net.Conn, err error) {
 	node, ok := s.GetNode(dest.ID)
 	if !ok {
 		return nil, fmt.Errorf("unknown node: %s", dest.ID)

--- a/p2p/sql_stmt.go
+++ b/p2p/sql_stmt.go
@@ -699,13 +699,19 @@ func (srv *Server) queueNodeMetaInfo(id discover.NodeID, hash string, dial bool,
 	}
 }
 
-func (srv *Server) queueNodeP2PInfo(id discover.NodeID, newInfo *Info) {
-	lastHelloAt := newInfo.LastHelloAt.Float64()
+func (srv *Server) queueNodeP2PInfo(id discover.NodeID, newInfo *Info) error {
+	if newInfo.FirstHelloAt == nil {
+		return fmt.Errorf("FirstHelloAt == nil")
+	}
+	if newInfo.LastHelloAt == nil {
+		return fmt.Errorf("LastHelloAt == nil")
+	}
 	srv.p2pInfoChan <- []interface{}{
 		id.String(), newInfo.IP, newInfo.TCPPort, newInfo.RemotePort,
 		newInfo.P2PVersion, newInfo.ClientId, newInfo.Caps, newInfo.ListenPort,
-		lastHelloAt, lastHelloAt,
+		newInfo.FirstHelloAt.Float64(), newInfo.LastHelloAt.Float64(),
 	}
+	return nil
 }
 
 func boolToInt(b bool) int {


### PR DESCRIPTION
- [x] `discoverTask` starts, regardless of number of concurrently running tasks. The task is started as soon as it's generated, instead of being added to a queue. The `discoverTask` generating conditions remain the same as that of the original geth logic.
  - Discovery happens much more frequently now, but it still doesn't seem to occur as often as normal geth.
  - Maybe force discovery every 4 sec even if the currently running hasn't finished?
- [x] `DialCheckFreq` flag. Default is 15 seconds.
- [x] AddBlacklist JS console function currently allows updating TCP dialer/listener's setting dynamically. The UDP dialer/listener's setting should be updated as well.
- [x] Reverted TCP dialer with cancel context back to normal dialer.
  - Running tasks are ignored during p2p server shutdown. There is no need for manually cancelling them.
- [x] Reverted `dialTask` behavior back to original.
  - We DO want node-finder to resolve address of static nodes if it fails to connect to them.
- [x] New log level `TASK` for `New dial task` and `Dial task done` messages.
- [x] New log level `PEER` for messages related adding or removing p2p/ethereum peer connections.