### PR TITLE
node-finder limit number of concurrent static dialtasks

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -57,6 +57,7 @@ var (
 	// flags that configure the node
 	nodeFlags = []cli.Flag{
 		utils.MaxDialFlag,
+		utils.MaxRedialFlag,
 		utils.MaxNumFileFlag,
 		utils.BlacklistFlag,
 		utils.RedialFreqFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -72,6 +72,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.RedialFreqFlag,
 			utils.RedialCheckFreqFlag,
 			utils.MaxNumFileFlag,
+			utils.MaxRedialFlag,
 			utils.BlacklistFlag,
 			utils.PushFreqFlag,
 			utils.MaxPendingPeersFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -118,6 +118,11 @@ var (
 		Usage: "Maximum number of concurrently dialing outbound connections",
 		Value: 16,
 	}
+	MaxRedialFlag = cli.IntFlag{
+		Name:  "maxredial",
+		Usage: "Maximum number of concurrently re-dialing outbound connections",
+		Value: 1000,
+	}
 	MaxNumFileFlag = cli.Uint64Flag{
 		Name:  "maxnumfile",
 		Usage: "Maximum file descriptor allowance of this process (try 1048576)",
@@ -854,6 +859,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	}
 	if ctx.GlobalIsSet(MaxDialFlag.Name) {
 		cfg.MaxDial = ctx.GlobalInt(MaxDialFlag.Name)
+	}
+	if ctx.GlobalIsSet(MaxRedialFlag.Name) {
+		cfg.MaxRedial = ctx.GlobalInt(MaxRedialFlag.Name)
 	}
 
 	if ctx.GlobalIsSet(MaxPeersFlag.Name) {

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -46,6 +46,7 @@ var DefaultConfig = Config{
 		MaxPeers:        25,
 		NAT:             nat.Any(),
 		MaxDial:         16,
+		MaxRedial:       1000,
 		NoMaxPeers:      true, // node-finder never limits number of peers
 		RedialFreq:      30.0,
 		RedialCheckFreq: 5.0,

--- a/scripts/node-finder-loop.sh
+++ b/scripts/node-finder-loop.sh
@@ -38,6 +38,7 @@ do
     --redialfreq 1800 \
     --redialcheckfreq 5 \
     --maxnumfile 20480 \
+    --maxredial 1000 \
     --pushfreq 1 >>${ERRFILE} 2>&1
   echo "${NODEFINDER_NAME}-${i} stopped. restarting in ${SLEEP} seconds..."
   sleep ${SLEEP}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -64,6 +64,7 @@ do
     --redialfreq 1800 \
     --redialcheckfreq 5 \
     --maxnumfile 20480 \
+    --maxredial 1000 \
     --pushfreq 1"
   docker run -dit --restart=always -h ${NODEFINDER_NAME}-${i} --name ${NODEFINDER_NAME}-${i} --net host -v ${NODEFINDER_DIR}:${DATADIR} -e CMD="${CMD}" --entrypoint '/bin/sh' ${NODEFINDER_IMAGE} -c "${CMD}"
  echo "${NODEFINDER_NAME}-${i} started"


### PR DESCRIPTION
- [x] Allow setting max number of concurrent static dials. default is 1000. min is equal to `MaxDial` (max number of concurrent dyn dials).