### PR TITLE
eth-monitor v2

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -229,14 +229,13 @@ func (pm *ProtocolManager) handle(p *peer) error {
 	p.Log().Debug("Ethereum peer connected", "name", p.Name())
 
 	// Execute the Ethereum handshake
-	td, head, genesis := pm.blockchain.Status()
+	td, _, genesis := pm.blockchain.Status()
 
-	// if mainnet, always advertise block 1920001 as our head
+	// always advertise block 0 as our head
 	if genesis == params.MainnetGenesisHash && pm.networkId == 1 {
-		td, _ = td.SetString("39491026755346691452", 10)
-		head = common.HexToHash("87b2bc3f12e3ded808c6d4b9b528381fa2a7e95ff2368ba93191a9495daa7f50")
+		td, _ = td.SetString("17179869184", 10)
 	}
-	if err := p.Handshake(pm.networkId, td, head, genesis); err != nil {
+	if err := p.Handshake(pm.networkId, td, genesis, genesis); err != nil {
 		p.Log().Debug("Ethereum handshake failed", "err", err)
 		return err
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -229,13 +229,14 @@ func (pm *ProtocolManager) handle(p *peer) error {
 	p.Log().Debug("Ethereum peer connected", "name", p.Name())
 
 	// Execute the Ethereum handshake
-	td, _, genesis := pm.blockchain.Status()
+	td, head, genesis := pm.blockchain.Status()
 
 	// always advertise block 0 as our head
 	if genesis == params.MainnetGenesisHash && pm.networkId == 1 {
 		td, _ = td.SetString("17179869184", 10)
+		head = genesis
 	}
-	if err := p.Handshake(pm.networkId, td, genesis, genesis); err != nil {
+	if err := p.Handshake(pm.networkId, td, head, genesis); err != nil {
 		p.Log().Debug("Ethereum handshake failed", "err", err)
 		return err
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -294,18 +294,22 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 	}
 	defer msg.Discard()
 
-	connInfoCtx := p.ConnInfoCtx()
+	connInfoCtx := p.ConnInfoCtx(
+		"mss", p.MssRx(),
+		"rtt", msg.Rtt,
+		"duration", msg.PeerDuration,
+	)
 	msgType, ok := ethCodeToString[msg.Code]
 	if !ok {
 		msgType = fmt.Sprintf("UNKNOWN_%v", msg.Code)
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 		return p.suppressMessageError(errResp(ErrInvalidMsgCode, "%v", msg.Code))
 	}
 	// Handle the message depending on its contents
 	switch {
 	case msg.Code == StatusMsg:
 		// Status messages should never arrive after the handshake
-		log.MessageRx(msg.ReceivedAt, "<<UNEXPECTED_"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<UNEXPECTED_"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 		return p.suppressMessageError(errResp(ErrExtraStatusMsg, "uncontrolled status message"))
 
 	// Block header query, collect the requested headers and reply
@@ -313,10 +317,10 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Decode the complex header query
 		var query getBlockHeadersData
 		if err := msg.Decode(&query); err != nil {
-			log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, err)
+			log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, err)
 			return p.suppressMessageError(errResp(ErrDecode, "%v: %v", msg, err))
 		}
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 		hashMode := query.Origin.Hash != (common.Hash{})
 
 		// Gather headers until the fetch or network limits is reached
@@ -398,10 +402,10 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// A batch of headers arrived to one of our previous requests
 		var headers []*types.Header
 		if err := msg.Decode(&headers); err != nil {
-			log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, err)
+			log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, err)
 			return p.suppressMessageError(errResp(ErrDecode, "msg %v: %v", msg, err))
 		}
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 		// If no headers were received, but we're expending a DAO fork check, maybe it's that
 		if len(headers) == 0 && p.forkDrop != nil {
 			// Possibly an empty reply to the fork header checks, sanity check TDs
@@ -444,10 +448,10 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Decode the retrieval message
 		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 		if _, err := msgStream.List(); err != nil {
-			log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, err)
+			log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, err)
 			return p.suppressMessageError(err)
 		}
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 		// Gather blocks until the fetch or network limits is reached
 		var (
 			hash   common.Hash
@@ -473,10 +477,10 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Decode the retrieval message
 		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 		if _, err := msgStream.List(); err != nil {
-			log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, err)
+			log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, err)
 			return p.suppressMessageError(err)
 		}
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 		// Gather state data until the fetch or network limits is reached
 		var (
 			hash  common.Hash
@@ -502,10 +506,10 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Decode the retrieval message
 		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 		if _, err := msgStream.List(); err != nil {
-			log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, err)
+			log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, err)
 			return p.suppressMessageError(err)
 		}
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 		// Gather state data until the fetch or network limits is reached
 		var (
 			hash     common.Hash
@@ -539,25 +543,25 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 	case msg.Code == NewBlockHashesMsg:
 		var announces newBlockHashesData
 		if err := msg.Decode(&announces); err != nil {
-			log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, err)
+			log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, err)
 			return p.suppressMessageError(errResp(ErrDecode, "%v: %v", msg, err))
 		}
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 
 		// Mark the hashes as present at the remote node
 		for _, block := range announces {
 			// log the hash of the block
-			log.NewBlockHashesRx(msg.ReceivedAt, connInfoCtx, msg.PeerRtt, msg.PeerDuration, block.Hash.String()[2:], block.Number)
+			log.NewBlockHashesRx(msg.ReceivedAt, connInfoCtx, msg.Size, msg.EncodedSize, block.Hash.String()[2:], block.Number)
 		}
 
 	case msg.Code == NewBlockMsg:
 		// Retrieve and decode the propagated block
 		var request newBlockData
 		if err := msg.Decode(&request); err != nil {
-			log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, err)
+			log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, err)
 			return p.suppressMessageError(errResp(ErrDecode, "%v: %v", msg, err))
 		}
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 
 		blockHash := request.Block.Hash()
 
@@ -565,21 +569,21 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		pm.knownBlocks.Lock()
 		if _, ok := pm.knownBlocks.known[blockHash]; !ok {
 			pm.knownBlocks.known[blockHash] = struct{}{}
-			log.NewBlockData(msg.ReceivedAt, connInfoCtx, msg.PeerRtt, msg.PeerDuration, request.Block.LogString())
+			log.NewBlockData(msg.ReceivedAt, connInfoCtx, msg.Size, msg.EncodedSize, request.Block.LogString())
 		}
 		pm.knownBlocks.Unlock()
 
 		// log the hash and number of the block
-		log.NewBlockRx(msg.ReceivedAt, connInfoCtx, msg.PeerRtt, msg.PeerDuration, blockHash.String()[2:], request.Block.Number().String())
+		log.NewBlockRx(msg.ReceivedAt, connInfoCtx, msg.Size, msg.EncodedSize, blockHash.String()[2:], request.Block.Number().String())
 
 	case msg.Code == TxMsg:
 		// Transactions can be processed, parse all of them and deliver to the pool
 		var txs []*types.Transaction
 		if err := msg.Decode(&txs); err != nil {
-			log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, err)
+			log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, err)
 			return p.suppressMessageError(errResp(ErrDecode, "msg %v: %v", msg, err))
 		}
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 
 		for i, tx := range txs {
 			// Validate and mark the remote transaction
@@ -593,16 +597,16 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			pm.knownTxs.Lock()
 			if _, ok := pm.knownTxs.known[txHash]; !ok {
 				pm.knownTxs.known[txHash] = struct{}{}
-				log.TxData(msg.ReceivedAt, connInfoCtx, msg.PeerRtt, msg.PeerDuration, tx.LogString())
+				log.TxData(msg.ReceivedAt, connInfoCtx, msg.Size, msg.EncodedSize, tx.LogString())
 			}
 			pm.knownTxs.Unlock()
 
 			// log the hash of the tx
-			log.TxRx(msg.ReceivedAt, connInfoCtx, msg.PeerRtt, msg.PeerDuration, txHash.String()[2:])
+			log.TxRx(msg.ReceivedAt, connInfoCtx, msg.Size, msg.EncodedSize, txHash.String()[2:])
 		}
 
 	default:
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 	}
 	return nil
 }

--- a/eth/metrics.go
+++ b/eth/metrics.go
@@ -110,7 +110,7 @@ func (rw *meteredMsgReadWriter) ReadMsg() (p2p.Msg, error) {
 	return msg, err
 }
 
-func (rw *meteredMsgReadWriter) WriteMsg(msg p2p.Msg) error {
+func (rw *meteredMsgReadWriter) WriteMsg(msg p2p.Msg) (uint32, error) {
 	// Account for the data traffic
 	packets, traffic := miscOutPacketsMeter, miscOutTrafficMeter
 	switch {

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -145,7 +145,7 @@ func (p *peer) SendTransactions(txs types.Transactions) error {
 	for _, tx := range txs {
 		p.knownTxs.Add(tx.Hash())
 	}
-	return p2p.Send(p.rw, TxMsg, txs)
+	return p2p.Send(p.rw, TxMsg, txs, p.TxConnInfoCtx()...)
 }
 
 // SendNewBlockHashes announces the availability of a number of blocks through
@@ -159,82 +159,82 @@ func (p *peer) SendNewBlockHashes(hashes []common.Hash, numbers []uint64) error 
 		request[i].Hash = hashes[i]
 		request[i].Number = numbers[i]
 	}
-	return p2p.SendEthSubproto(p.rw, NewBlockHashesMsg, request, p.ConnInfoCtx()...)
+	return p2p.SendEthSubproto(p.rw, NewBlockHashesMsg, request, p.TxConnInfoCtx()...)
 }
 
 // SendNewBlock propagates an entire block to a remote peer.
 func (p *peer) SendNewBlock(block *types.Block, td *big.Int) error {
 	p.knownBlocks.Add(block.Hash())
-	return p2p.SendEthSubproto(p.rw, NewBlockMsg, []interface{}{block, td}, p.ConnInfoCtx()...)
+	return p2p.SendEthSubproto(p.rw, NewBlockMsg, []interface{}{block, td}, p.TxConnInfoCtx()...)
 }
 
 // SendBlockHeaders sends a batch of block headers to the remote peer.
 func (p *peer) SendBlockHeaders(headers []*types.Header) error {
-	return p2p.SendEthSubproto(p.rw, BlockHeadersMsg, headers, p.ConnInfoCtx()...)
+	return p2p.SendEthSubproto(p.rw, BlockHeadersMsg, headers, p.TxConnInfoCtx()...)
 }
 
 // SendBlockBodies sends a batch of block contents to the remote peer.
 func (p *peer) SendBlockBodies(bodies []*blockBody) error {
-	return p2p.SendEthSubproto(p.rw, BlockBodiesMsg, blockBodiesData(bodies), p.ConnInfoCtx()...)
+	return p2p.SendEthSubproto(p.rw, BlockBodiesMsg, blockBodiesData(bodies), p.TxConnInfoCtx()...)
 }
 
 // SendBlockBodiesRLP sends a batch of block contents to the remote peer from
 // an already RLP encoded format.
 func (p *peer) SendBlockBodiesRLP(bodies []rlp.RawValue) error {
-	return p2p.SendEthSubproto(p.rw, BlockBodiesMsg, bodies, p.ConnInfoCtx()...)
+	return p2p.SendEthSubproto(p.rw, BlockBodiesMsg, bodies, p.TxConnInfoCtx()...)
 }
 
 // SendNodeDataRLP sends a batch of arbitrary internal data, corresponding to the
 // hashes requested.
 func (p *peer) SendNodeData(data [][]byte) error {
-	return p2p.SendEthSubproto(p.rw, NodeDataMsg, data, p.ConnInfoCtx()...)
+	return p2p.SendEthSubproto(p.rw, NodeDataMsg, data, p.TxConnInfoCtx()...)
 }
 
 // SendReceiptsRLP sends a batch of transaction receipts, corresponding to the
 // ones requested from an already RLP encoded format.
 func (p *peer) SendReceiptsRLP(receipts []rlp.RawValue) error {
-	return p2p.SendEthSubproto(p.rw, ReceiptsMsg, receipts, p.ConnInfoCtx()...)
+	return p2p.SendEthSubproto(p.rw, ReceiptsMsg, receipts, p.TxConnInfoCtx()...)
 }
 
 // RequestOneHeader is a wrapper around the header query functions to fetch a
 // single header. It is used solely by the fetcher.
 func (p *peer) RequestOneHeader(hash common.Hash) error {
 	p.Log().Debug("Fetching single header", "hash", hash)
-	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: hash}, Amount: uint64(1), Skip: uint64(0), Reverse: false}, p.ConnInfoCtx()...)
+	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: hash}, Amount: uint64(1), Skip: uint64(0), Reverse: false}, p.TxConnInfoCtx()...)
 }
 
 // RequestHeadersByHash fetches a batch of blocks' headers corresponding to the
 // specified header query, based on the hash of an origin block.
 func (p *peer) RequestHeadersByHash(origin common.Hash, amount int, skip int, reverse bool) error {
 	p.Log().Debug("Fetching batch of headers", "count", amount, "fromhash", origin, "skip", skip, "reverse", reverse)
-	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse}, p.ConnInfoCtx()...)
+	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse}, p.TxConnInfoCtx()...)
 }
 
 // RequestHeadersByNumber fetches a batch of blocks' headers corresponding to the
 // specified header query, based on the number of an origin block.
 func (p *peer) RequestHeadersByNumber(origin uint64, amount int, skip int, reverse bool) error {
 	p.Log().Debug("Fetching batch of headers", "count", amount, "fromnum", origin, "skip", skip, "reverse", reverse)
-	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Number: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse}, p.ConnInfoCtx()...)
+	return p2p.SendEthSubproto(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Number: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse}, p.TxConnInfoCtx()...)
 }
 
 // RequestBodies fetches a batch of blocks' bodies corresponding to the hashes
 // specified.
 func (p *peer) RequestBodies(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of block bodies", "count", len(hashes))
-	return p2p.SendEthSubproto(p.rw, GetBlockBodiesMsg, hashes, p.ConnInfoCtx()...)
+	return p2p.SendEthSubproto(p.rw, GetBlockBodiesMsg, hashes, p.TxConnInfoCtx()...)
 }
 
 // RequestNodeData fetches a batch of arbitrary data from a node's known state
 // data, corresponding to the specified hashes.
 func (p *peer) RequestNodeData(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of state data", "count", len(hashes))
-	return p2p.SendEthSubproto(p.rw, GetNodeDataMsg, hashes, p.ConnInfoCtx()...)
+	return p2p.SendEthSubproto(p.rw, GetNodeDataMsg, hashes, p.TxConnInfoCtx()...)
 }
 
 // RequestReceipts fetches a batch of transaction receipts from a remote node.
 func (p *peer) RequestReceipts(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of receipts", "count", len(hashes))
-	return p2p.SendEthSubproto(p.rw, GetReceiptsMsg, hashes, p.ConnInfoCtx()...)
+	return p2p.SendEthSubproto(p.rw, GetReceiptsMsg, hashes, p.TxConnInfoCtx()...)
 }
 
 // Handshake executes the eth protocol handshake, negotiating version number,
@@ -251,7 +251,7 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 			TD:              td,
 			CurrentBlock:    head,
 			GenesisBlock:    genesis,
-		}, p.ConnInfoCtx()...)
+		}, p.TxConnInfoCtx()...)
 	}()
 	go func() {
 		errc <- p.readStatus(network, &status, genesis)
@@ -277,25 +277,29 @@ func (p *peer) readStatus(network uint64, status *statusData, genesis common.Has
 	if err != nil {
 		return err
 	}
-	connInfoCtx := p.ConnInfoCtx()
+	connInfoCtx := p.ConnInfoCtx(
+		"mss", p.MssRx(),
+		"rtt", msg.Rtt,
+		"duration", msg.PeerDuration,
+	)
 	msgType, ok := ethCodeToString[msg.Code]
 	if !ok {
 		msgType = fmt.Sprintf("UNKNOWN_%v", msg.Code)
 	}
 	if msg.Code != StatusMsg {
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 		return errResp(ErrNoStatusMsg, "first msg has code %x (!= %x)", msg.Code, StatusMsg)
 	}
 	if msg.Size > ProtocolMaxMsgSize {
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 		return errResp(ErrMsgTooLarge, "%v > %v", msg.Size, ProtocolMaxMsgSize)
 	}
 	// Decode the handshake and make sure everything matches
 	if err := msg.Decode(&status); err != nil {
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, err)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, err)
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
-	log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+	log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 	if status.GenesisBlock != genesis {
 		return errResp(ErrGenesisBlockMismatch, "%x (!= %x)", status.GenesisBlock[:8], genesis[:8])
 	}

--- a/les/metrics.go
+++ b/les/metrics.go
@@ -100,7 +100,7 @@ func (rw *meteredMsgReadWriter) ReadMsg() (p2p.Msg, error) {
 	return msg, err
 }
 
-func (rw *meteredMsgReadWriter) WriteMsg(msg p2p.Msg) error {
+func (rw *meteredMsgReadWriter) WriteMsg(msg p2p.Msg) (uint32, error) {
 	// Account for the data traffic
 	packets, traffic := miscOutPacketsMeter, miscOutTrafficMeter
 	packets.Mark(1)

--- a/log/logger.go
+++ b/log/logger.go
@@ -201,17 +201,17 @@ type Logger interface {
 	GetGlogger() *GlogHandler
 
 	// Log a message at the given level with context key/value pairs
-	NewBlockHashesTx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, blockHash string, blockNumber string)
-	NewBlockHashesRx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, blockHash string, blockNumber string)
-	NewBlockTx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, blockHash string, blockNumber string)
-	NewBlockRx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, blockHash string, blockNumber string)
-	NewBlockData(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, block string)
-	TxTx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, txHash string)
-	TxRx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, txHash string)
-	TxData(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, tx string)
+	NewBlockHashesTx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, blockHash string, blockNumber string)
+	NewBlockHashesRx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, blockHash string, blockNumber string)
+	NewBlockTx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, blockHash string, blockNumber string)
+	NewBlockRx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, blockHash string, blockNumber string)
+	NewBlockData(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, block string)
+	TxTx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, txHash string)
+	TxRx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, txHash string)
+	TxData(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, tx string)
 	Task(msg string, taskInfoCtx []interface{})
-	MessageTx(t time.Time, msgType string, size int, connInfoCtx []interface{}, err error)
-	MessageRx(t time.Time, msgType string, size int, connInfoCtx []interface{}, err error)
+	MessageTx(t time.Time, msgType string, size uint32, encodedSize uint32, connInfoCtx []interface{}, err error)
+	MessageRx(t time.Time, msgType string, size uint32, encodedSize uint32, connInfoCtx []interface{}, err error)
 	Sql(msg string, ctx ...interface{})
 	Trace(msg string, ctx ...interface{})
 	Debug(msg string, ctx ...interface{})
@@ -257,11 +257,11 @@ func newContext(prefix []interface{}, suffix []interface{}) []interface{} {
 	return newCtx
 }
 
-func (l *logger) writeTimeMsgType(lvl Lvl, t time.Time, msgType string, size int, connInfoCtx []interface{}, err error) {
-	ctx := []interface{}{
+func (l *logger) writeTimeMsgType(lvl Lvl, t time.Time, msgType string, size uint32, encodedSize uint32, connInfoCtx []interface{}, err error) {
+	ctx := append(connInfoCtx,
 		"size", size,
-	}
-	ctx = append(ctx, connInfoCtx...)
+		"encodedSize", encodedSize,
+	)
 	if err != nil {
 		ctx = append(ctx, "err", err)
 	}
@@ -272,87 +272,79 @@ func (l *logger) writeTime(lvl Lvl, t time.Time, ctx []interface{}) {
 	l.write(fmt.Sprintf("%.6f", float64(t.UnixNano())/1e9), lvl, ctx)
 }
 
-func (l *logger) NewBlockHashesTx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, blockHash string, blockNumber string) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func (l *logger) NewBlockHashesTx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, blockHash string, blockNumber string) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"blockHash", blockHash,
 		"blockNumber", blockNumber,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	l.writeTime(LvlNewBlockHashesTx, t, ctx)
 }
 
-func (l *logger) NewBlockHashesRx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, blockHash string, blockNumber string) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func (l *logger) NewBlockHashesRx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, blockHash string, blockNumber string) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"blockHash", blockHash,
 		"blockNumber", blockNumber,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	l.writeTime(LvlNewBlockHashesRx, t, ctx)
 }
 
-func (l *logger) NewBlockTx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, blockHash string, blockNumber string) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func (l *logger) NewBlockTx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, blockHash string, blockNumber string) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"blockHash", blockHash,
 		"blockNumber", blockNumber,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	l.writeTime(LvlNewBlockTx, t, ctx)
 }
 
-func (l *logger) NewBlockRx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, blockHash string, blockNumber string) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func (l *logger) NewBlockRx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, blockHash string, blockNumber string) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"blockHash", blockHash,
 		"blockNumber", blockNumber,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	l.writeTime(LvlNewBlockRx, t, ctx)
 }
 
-func (l *logger) NewBlockData(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, block string) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func (l *logger) NewBlockData(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, block string) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"block", block,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	l.writeTime(LvlNewBlockData, t, ctx)
 }
 
-func (l *logger) TxTx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, txHash string) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func (l *logger) TxTx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, txHash string) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"txHash", txHash,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	l.writeTime(LvlTxTx, t, ctx)
 }
 
-func (l *logger) TxRx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, txHash string) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func (l *logger) TxRx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, txHash string) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"txHash", txHash,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	l.writeTime(LvlTxRx, t, ctx)
 }
 
-func (l *logger) TxData(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, tx string) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func (l *logger) TxData(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, tx string) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"tx", tx,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	l.writeTime(LvlTxData, t, ctx)
 }
 
@@ -360,12 +352,12 @@ func (l *logger) Task(msg string, taskInfoCtx []interface{}) {
 	l.write(msg, LvlTask, taskInfoCtx)
 }
 
-func (l *logger) MessageTx(t time.Time, msgType string, size int, connInfoCtx []interface{}, err error) {
-	l.writeTimeMsgType(LvlMessageTx, t, msgType, size, connInfoCtx, err)
+func (l *logger) MessageTx(t time.Time, msgType string, size uint32, encodedSize uint32, connInfoCtx []interface{}, err error) {
+	l.writeTimeMsgType(LvlMessageTx, t, msgType, size, encodedSize, connInfoCtx, err)
 }
 
-func (l *logger) MessageRx(t time.Time, msgType string, size int, connInfoCtx []interface{}, err error) {
-	l.writeTimeMsgType(LvlMessageRx, t, msgType, size, connInfoCtx, err)
+func (l *logger) MessageRx(t time.Time, msgType string, size uint32, encodedSize uint32, connInfoCtx []interface{}, err error) {
+	l.writeTimeMsgType(LvlMessageRx, t, msgType, size, encodedSize, connInfoCtx, err)
 }
 
 func (l *logger) Sql(msg string, ctx ...interface{}) {

--- a/log/root.go
+++ b/log/root.go
@@ -30,87 +30,79 @@ func Root() Logger {
 // etc.) to keep the call depth the same for all paths to logger.write so
 // runtime.Caller(2) always refers to the call site in client code.
 
-func NewBlockHashesTx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, blockHash string, blockNumber uint64) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func NewBlockHashesTx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, blockHash string, blockNumber uint64) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"blockHash", blockHash,
 		"blockNumber", blockNumber,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	root.writeTime(LvlNewBlockHashesTx, t, ctx)
 }
 
-func NewBlockHashesRx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, blockHash string, blockNumber uint64) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func NewBlockHashesRx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, blockHash string, blockNumber uint64) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"blockHash", blockHash,
 		"blockNumber", blockNumber,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	root.writeTime(LvlNewBlockHashesRx, t, ctx)
 }
 
-func NewBlockTx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, blockHash string, blockNumber string) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func NewBlockTx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, blockHash string, blockNumber string) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"blockHash", blockHash,
 		"blockNumber", blockNumber,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	root.writeTime(LvlNewBlockTx, t, ctx)
 }
 
-func NewBlockRx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, blockHash string, blockNumber string) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func NewBlockRx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, blockHash string, blockNumber string) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"blockHash", blockHash,
 		"blockNumber", blockNumber,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	root.writeTime(LvlNewBlockRx, t, ctx)
 }
 
-func NewBlockData(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, block string) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func NewBlockData(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, block string) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"block", block,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	root.writeTime(LvlNewBlockData, t, ctx)
 }
 
-func TxTx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, txHash string) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func TxTx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, txHash string) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"txHash", txHash,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	root.writeTime(LvlTxTx, t, ctx)
 }
 
-func TxRx(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, txHash string) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func TxRx(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, txHash string) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"txHash", txHash,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	root.writeTime(LvlTxRx, t, ctx)
 }
 
-func TxData(t time.Time, connInfoCtx []interface{}, rtt float64, duration float64, tx string) {
-	ctx := []interface{}{
-		"rtt", rtt,
-		"duration", duration,
+func TxData(t time.Time, connInfoCtx []interface{}, size uint32, encodedSize uint32, tx string) {
+	ctx := append(connInfoCtx,
+		"size", size,
+		"encodedSize", encodedSize,
 		"tx", tx,
-	}
-	ctx = append(connInfoCtx, ctx...)
+	)
 	root.writeTime(LvlTxData, t, ctx)
 }
 
@@ -118,12 +110,12 @@ func Task(msg string, taskInfoCtx []interface{}) {
 	root.write(msg, LvlTask, taskInfoCtx)
 }
 
-func MessageTx(t time.Time, msgType string, size int, connInfoCtx []interface{}, err error) {
-	root.writeTimeMsgType(LvlMessageTx, t, msgType, size, connInfoCtx, err)
+func MessageTx(t time.Time, msgType string, size uint32, encodedSize uint32, connInfoCtx []interface{}, err error) {
+	root.writeTimeMsgType(LvlMessageTx, t, msgType, size, encodedSize, connInfoCtx, err)
 }
 
-func MessageRx(t time.Time, msgType string, size int, connInfoCtx []interface{}, err error) {
-	root.writeTimeMsgType(LvlMessageRx, t, msgType, size, connInfoCtx, err)
+func MessageRx(t time.Time, msgType string, size uint32, encodedSize uint32, connInfoCtx []interface{}, err error) {
+	root.writeTimeMsgType(LvlMessageRx, t, msgType, size, encodedSize, connInfoCtx, err)
 }
 
 func Sql(msg string, ctx ...interface{}) {

--- a/node/api.go
+++ b/node/api.go
@@ -156,9 +156,11 @@ func (api *PublicAdminAPI) PeerList() (string, error) {
 		localAddr := info.Network.LocalAddress
 		remoteAddr := info.Network.RemoteAddress
 		connType := info.Conn
+		mssTx := info.MssTx
+		mssRx := info.MssRx
 		rtt := info.Rtt
 		duration := info.Duration
-		p2pInfoStr := fmt.Sprintf("%s|%v|%v|%s|%.6f|%.6f|%v|%v", id, remoteAddr, localAddr, connType, rtt, duration, name, caps)
+		p2pInfoStr := fmt.Sprintf("%s|%v|%v|%s|%v|%v|%.6f|%.6f|%v|%v", id, remoteAddr, localAddr, connType, mssTx, mssRx, rtt, duration, name, caps)
 		var ethInfoStr string
 		if ethInfo := info.Protocols["eth"]; ethInfo != nil {
 			r := reflect.ValueOf(ethInfo)

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -488,7 +488,7 @@ func (t *udp) send(toaddr *net.UDPAddr, ptype byte, req packet, peer NodeID) err
 		"id", peer.String(),
 		"addr", toaddr.String(),
 	}
-	log.MessageTx(currentTime, ">>"+req.name(), len(packet), connInfoCtx, err)
+	log.MessageTx(currentTime, ">>"+req.name(), uint32(len(packet)), uint32(len(packet)), connInfoCtx, err)
 	return err
 }
 
@@ -547,7 +547,7 @@ func (t *udp) handlePacket(from *net.UDPAddr, buf []byte) error {
 		"id", fromID.String(),
 		"addr", from.String(),
 	}
-	log.MessageRx(currentTime, "<<"+packet.name(), len(buf), connInfoCtx, nil)
+	log.MessageRx(currentTime, "<<"+packet.name(), uint32(len(buf)), uint32(len(buf)), connInfoCtx, nil)
 	err = packet.handle(t, from, fromID, hash)
 	return err
 }

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -43,9 +43,10 @@ import (
 type Msg struct {
 	Code         uint64
 	Size         uint32 // size of the paylod
+	EncodedSize  uint32
 	Payload      io.Reader
 	ReceivedAt   time.Time
-	PeerRtt      float64
+	Rtt          float64
 	PeerDuration float64
 }
 
@@ -81,7 +82,7 @@ type MsgWriter interface {
 	//
 	// Note that messages can be sent only once because their
 	// payload reader is drained.
-	WriteMsg(Msg) error
+	WriteMsg(Msg) (uint32, error)
 }
 
 // MsgReadWriter provides reading and writing of encoded messages.
@@ -98,12 +99,12 @@ func SendEthSubproto(w MsgWriter, msgcode uint64, data interface{}, connInfoCtx 
 		return err
 	}
 	currentTime := time.Now()
-	err = w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
+	encodedSize, err := w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 	msgType, ok := ethCodeToString[msgcode]
 	if !ok {
 		msgType = fmt.Sprintf("UNKNOWN_%v", msgcode)
 	}
-	log.MessageTx(currentTime, ">>"+msgType, size, connInfoCtx, err)
+	log.MessageTx(currentTime, ">>"+msgType, uint32(size), encodedSize, connInfoCtx, err)
 	return err
 }
 
@@ -115,12 +116,12 @@ func Send(w MsgWriter, msgcode uint64, data interface{}, connInfoCtx ...interfac
 		return err
 	}
 	currentTime := time.Now()
-	err = w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
+	encodedSize, err := w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 	msgType, ok := devp2pCodeToString[msgcode]
 	if !ok {
 		msgType = fmt.Sprintf("UNKNOWN_%v", msgcode)
 	}
-	log.MessageTx(currentTime, ">>"+msgType, size, connInfoCtx, err)
+	log.MessageTx(currentTime, ">>"+msgType, uint32(size), encodedSize, connInfoCtx, err)
 	return err
 }
 
@@ -154,7 +155,7 @@ func (rw *netWrapper) ReadMsg() (Msg, error) {
 	return rw.wrapped.ReadMsg()
 }
 
-func (rw *netWrapper) WriteMsg(msg Msg) error {
+func (rw *netWrapper) WriteMsg(msg Msg) (uint32, error) {
 	rw.wmu.Lock()
 	defer rw.wmu.Unlock()
 	rw.conn.SetWriteDeadline(time.Now().Add(rw.wtimeout))
@@ -222,7 +223,7 @@ type MsgPipeRW struct {
 
 // WriteMsg sends a messsage on the pipe.
 // It blocks until the receiver has consumed the message payload.
-func (p *MsgPipeRW) WriteMsg(msg Msg) error {
+func (p *MsgPipeRW) WriteMsg(msg Msg) (total uint32, err error) {
 	if atomic.LoadInt32(p.closed) == 0 {
 		consumed := make(chan struct{}, 1)
 		msg.Payload = &eofSignal{msg.Payload, msg.Size, consumed}
@@ -235,11 +236,11 @@ func (p *MsgPipeRW) WriteMsg(msg Msg) error {
 				case <-p.closing:
 				}
 			}
-			return nil
+			return total, nil
 		case <-p.closing:
 		}
 	}
-	return ErrPipeClosed
+	return total, ErrPipeClosed
 }
 
 // ReadMsg returns a message sent on the other end of the pipe.
@@ -339,10 +340,10 @@ func (self *msgEventer) ReadMsg() (Msg, error) {
 
 // WriteMsg writes a message to the underlying MsgReadWriter and emits a
 // "message sent" event
-func (self *msgEventer) WriteMsg(msg Msg) error {
-	err := self.MsgReadWriter.WriteMsg(msg)
+func (self *msgEventer) WriteMsg(msg Msg) (uint32, error) {
+	total, err := self.MsgReadWriter.WriteMsg(msg)
 	if err != nil {
-		return err
+		return total, err
 	}
 	self.feed.Send(&PeerEvent{
 		Type:     PeerEventTypeMsgSend,
@@ -351,7 +352,7 @@ func (self *msgEventer) WriteMsg(msg Msg) error {
 		MsgCode:  &msg.Code,
 		MsgSize:  &msg.Size,
 	})
-	return nil
+	return total, nil
 }
 
 // Close closes the underlying MsgReadWriter if it implements the io.Closer

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -177,6 +177,20 @@ func (p *Peer) Caps() []Cap {
 	return p.rw.caps
 }
 
+func (p *Peer) MssRx() uint32 {
+	if p.rw.transport == nil {
+		return 0
+	}
+	return p.rw.MssRx()
+}
+
+func (p *Peer) MssTx() uint32 {
+	if p.rw.transport == nil {
+		return 0
+	}
+	return p.rw.MssTx()
+}
+
 func (p *Peer) Rtt() float64 {
 	if p.rw.transport == nil {
 		return 0.0
@@ -236,8 +250,16 @@ func newPeer(conn *conn, protocols []Protocol) *Peer {
 	return p
 }
 
-func (p *Peer) ConnInfoCtx() []interface{} {
-	return p.rw.connInfoCtx
+func (p *Peer) ConnInfoCtx(ctx ...interface{}) []interface{} {
+	return append(p.rw.connInfoCtx, ctx...)
+}
+
+func (p *Peer) TxConnInfoCtx() []interface{} {
+	return p.ConnInfoCtx(
+		"mss", p.MssTx(),
+		"rtt", p.Rtt(),
+		"duration", p.Duration(),
+	)
 }
 
 func (p *Peer) IsInbound() bool {
@@ -296,7 +318,7 @@ loop:
 	}
 
 	close(p.closed)
-	p.rw.close(reason, p.ConnInfoCtx()...)
+	p.rw.close(reason, p.TxConnInfoCtx()...)
 	p.wg.Wait()
 	return remoteRequested, err
 }
@@ -308,7 +330,7 @@ func (p *Peer) pingLoop() {
 	for {
 		select {
 		case <-ping.C:
-			if err := SendItems(p.rw, pingMsg, p.ConnInfoCtx()); err != nil {
+			if err := SendItems(p.rw, pingMsg, p.TxConnInfoCtx()); err != nil {
 				p.protoErr <- err
 				return
 			}
@@ -336,35 +358,39 @@ func (p *Peer) readLoop(errc chan<- error) {
 }
 
 func (p *Peer) handle(msg Msg) error {
-	connInfoCtx := p.ConnInfoCtx()
+	connInfoCtx := p.ConnInfoCtx(
+		"mss", p.MssRx(),
+		"rtt", msg.Rtt,
+		"duration", msg.PeerDuration,
+	)
 	msgType, ok := devp2pCodeToString[msg.Code]
 	if !ok {
 		msgType = fmt.Sprintf("UNKNOWN_%v", msg.Code)
 	}
 	switch {
 	case msg.Code == pingMsg:
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 		msg.Discard()
 		go SendItems(p.rw, pongMsg, connInfoCtx)
 	case msg.Code == pongMsg:
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 		msg.Discard()
 	case msg.Code == discMsg:
 		var reason [1]DiscReason
 		// This is the last message. We don't need to discard or
 		// check errors because, the connection will be closed after it.
 		err := rlp.Decode(msg.Payload, &reason)
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, err)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, err)
 		return reason[0]
 	case msg.Code < baseProtocolLength:
-		log.MessageRx(msg.ReceivedAt, "<<"+msgType, int(msg.Size), connInfoCtx, nil)
+		log.MessageRx(msg.ReceivedAt, "<<"+msgType, msg.Size, msg.EncodedSize, connInfoCtx, nil)
 		// ignore other base protocol messages
 		return msg.Discard()
 	default:
 		// it's a subprotocol message
 		proto, err := p.getProto(msg.Code)
 		if err != nil {
-			log.MessageRx(msg.ReceivedAt, fmt.Sprintf("<<CODE_OUT_OF_RANGE_%v", msg.Code), int(msg.Size), connInfoCtx, err)
+			log.MessageRx(msg.ReceivedAt, fmt.Sprintf("<<CODE_OUT_OF_RANGE_%v", msg.Code), msg.Size, msg.EncodedSize, connInfoCtx, err)
 			return fmt.Errorf("msg code out of range: %v", msg.Code)
 		}
 		select {
@@ -461,14 +487,14 @@ type protoRW struct {
 	w      MsgWriter
 }
 
-func (rw *protoRW) WriteMsg(msg Msg) (err error) {
+func (rw *protoRW) WriteMsg(msg Msg) (total uint32, err error) {
 	if msg.Code >= rw.Length {
-		return newPeerError(errInvalidMsgCode, "not handled")
+		return total, newPeerError(errInvalidMsgCode, "not handled")
 	}
 	msg.Code += rw.offset
 	select {
 	case <-rw.wstart:
-		err = rw.w.WriteMsg(msg)
+		total, err = rw.w.WriteMsg(msg)
 		// Report write status back to Peer.run. It will initiate
 		// shutdown if the error is non-nil and unblock the next write
 		// otherwise. The calling protocol code should exit for errors
@@ -477,7 +503,7 @@ func (rw *protoRW) WriteMsg(msg Msg) (err error) {
 	case <-rw.closed:
 		err = fmt.Errorf("shutting down")
 	}
-	return err
+	return total, err
 }
 
 func (rw *protoRW) ReadMsg() (Msg, error) {
@@ -497,6 +523,8 @@ type PeerInfo struct {
 	ID       string   `json:"id"`   // Unique node identifier (also the encryption key)
 	Name     string   `json:"name"` // Name of the node, including client type, version, OS, custom data
 	Caps     []string `json:"caps"` // Sum-protocols advertised by this particular peer
+	MssTx    uint32   `json:"mssTx"`
+	MssRx    uint32   `json:"mssRx"`
 	Rtt      float64  `json:"rtt"`
 	Duration float64  `json:"duration"`
 	Network  struct {
@@ -523,6 +551,8 @@ func (p *Peer) Info() *PeerInfo {
 		Protocols: make(map[string]interface{}),
 	}
 	if p.rw.transport != nil {
+		info.MssTx = p.MssTx()
+		info.MssRx = p.MssRx()
 		info.Rtt = p.Rtt()
 	}
 	info.Network.LocalAddress = p.LocalAddr().String()

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -308,6 +308,15 @@ type setupTransport struct {
 	closeErr error
 }
 
+func (c *setupTransport) MssRx() uint32 {
+	return 0
+}
+func (c *setupTransport) MssTx() uint32 {
+	return 0
+}
+func (c *setupTransport) Rtt() float64 {
+	return 0.0
+}
 func (c *setupTransport) doEncHandshake(prv *ecdsa.PrivateKey, dialDest *discover.Node) (discover.NodeID, error) {
 	c.calls += "doEncHandshake,"
 	return c.id, c.encHandshakeErr
@@ -325,7 +334,7 @@ func (c *setupTransport) close(err error, connInfoCtx ...interface{}) {
 }
 
 // setupConn shouldn't write to/read from the connection.
-func (c *setupTransport) WriteMsg(Msg) error {
+func (c *setupTransport) WriteMsg(Msg) (uint32, error) {
 	panic("WriteMsg called on setupTransport")
 }
 func (c *setupTransport) ReadMsg() (Msg, error) {

--- a/p2p/sql_stmt.go
+++ b/p2p/sql_stmt.go
@@ -75,7 +75,7 @@ func (srv *Server) queryNodeAddress(interval time.Duration) error {
 				(SELECT all_addrs.node_id, ip, tcp_port 
 				 FROM (SELECT node_id, MAX(last_status_at) AS last_status_at 
 				 	   FROM node_eth_info 
-				 	   WHERE last_status_at >= ? and network_id = ? and genesis_hash = ? and dao_fork >= 0
+				 	   WHERE last_status_at >= ? and network_id = ? and genesis_hash = ? and dao_fork >= 0 and tcp_port != 0
 				 	   GROUP BY node_id
 				 	   ) AS new_ids 
 				 	INNER JOIN 

--- a/p2p/tcpinfo_darwin.go
+++ b/p2p/tcpinfo_darwin.go
@@ -10,6 +10,24 @@ import (
 	"github.com/teamnsrg/go-ethereum/tcpinfo"
 )
 
+// Receiver mss in bytes
+func (rw *rlpxFrameRW) MssRx() uint32 {
+	tcpInfo := rw.GetTCPInfo()
+	if tcpInfo == nil {
+		return 0
+	}
+	return tcpInfo.Maxseg
+}
+
+// Sender mss in bytes
+func (rw *rlpxFrameRW) MssTx() uint32 {
+	tcpInfo := rw.GetTCPInfo()
+	if tcpInfo == nil {
+		return 0
+	}
+	return tcpInfo.Maxseg
+}
+
 // Srtt in seconds (originally milliseconds)
 func (rw *rlpxFrameRW) Rtt() float64 {
 	tcpInfo := rw.GetTCPInfo()

--- a/p2p/tcpinfo_linux.go
+++ b/p2p/tcpinfo_linux.go
@@ -10,6 +10,24 @@ import (
 	"github.com/teamnsrg/go-ethereum/tcpinfo"
 )
 
+// Receiver mss in bytes
+func (rw *rlpxFrameRW) MssRx() uint32 {
+	tcpInfo := rw.GetTCPInfo()
+	if tcpInfo == nil {
+		return 0
+	}
+	return tcpInfo.Rcv_mss
+}
+
+// Sender mss in bytes
+func (rw *rlpxFrameRW) MssTx() uint32 {
+	tcpInfo := rw.GetTCPInfo()
+	if tcpInfo == nil {
+		return 0
+	}
+	return tcpInfo.Snd_mss
+}
+
 // Srtt in seconds (originally microseconds)
 func (rw *rlpxFrameRW) Rtt() float64 {
 	tcpInfo := rw.GetTCPInfo()


### PR DESCRIPTION
Version 2
- always announces genesis hash and difficulty as the current state, expecting no peers would choose ours as best peer
- does not respond to any request messages (`GetBlockBodies`, `GetNodeData`, `GetReceipts`)