### PR TITLE
eth-monitor correct encoded size for sent messages

### DIFF
--- a/eth/metrics.go
+++ b/eth/metrics.go
@@ -110,7 +110,7 @@ func (rw *meteredMsgReadWriter) ReadMsg() (p2p.Msg, error) {
 	return msg, err
 }
 
-func (rw *meteredMsgReadWriter) WriteMsg(msg p2p.Msg) error {
+func (rw *meteredMsgReadWriter) WriteMsg(msg p2p.Msg) (uint32, error) {
 	// Account for the data traffic
 	packets, traffic := miscOutPacketsMeter, miscOutTrafficMeter
 	switch {

--- a/les/metrics.go
+++ b/les/metrics.go
@@ -100,7 +100,7 @@ func (rw *meteredMsgReadWriter) ReadMsg() (p2p.Msg, error) {
 	return msg, err
 }
 
-func (rw *meteredMsgReadWriter) WriteMsg(msg p2p.Msg) error {
+func (rw *meteredMsgReadWriter) WriteMsg(msg p2p.Msg) (uint32, error) {
 	// Account for the data traffic
 	packets, traffic := miscOutPacketsMeter, miscOutTrafficMeter
 	packets.Mark(1)

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -97,7 +97,7 @@ func (t *rlpx) ReadMsg() (Msg, error) {
 	return t.rw.ReadMsg()
 }
 
-func (t *rlpx) WriteMsg(msg Msg) error {
+func (t *rlpx) WriteMsg(msg Msg) (uint32, error) {
 	t.wmu.Lock()
 	defer t.wmu.Unlock()
 	t.fd.SetWriteDeadline(time.Now().Add(frameWriteTimeout))
@@ -609,13 +609,14 @@ func newRLPXFrameRW(conn io.ReadWriter, tc *tcpConn, s secrets) *rlpxFrameRW {
 	}
 }
 
-func (rw *rlpxFrameRW) WriteMsg(msg Msg) error {
+func (rw *rlpxFrameRW) WriteMsg(msg Msg) (uint32, error) {
+	var total uint32
 	ptype, _ := rlp.EncodeToBytes(msg.Code)
 
 	// if snappy is enabled, compress message now
 	if rw.snappy {
 		if msg.Size > maxUint24 {
-			return errPlainMessageTooLarge
+			return total, errPlainMessageTooLarge
 		}
 		payload, _ := ioutil.ReadAll(msg.Payload)
 		payload = snappy.Encode(nil, payload)
@@ -627,7 +628,7 @@ func (rw *rlpxFrameRW) WriteMsg(msg Msg) error {
 	headbuf := make([]byte, 32)
 	fsize := uint32(len(ptype)) + msg.Size
 	if fsize > maxUint24 {
-		return errors.New("message size overflows uint24")
+		return total, errors.New("message size overflows uint24")
 	}
 	putInt24(fsize, headbuf) // TODO: check overflow
 	copy(headbuf[3:], zeroHeader)
@@ -636,22 +637,26 @@ func (rw *rlpxFrameRW) WriteMsg(msg Msg) error {
 	// write header MAC
 	copy(headbuf[16:], updateMAC(rw.egressMAC, rw.macCipher, headbuf[:16]))
 	if _, err := rw.conn.Write(headbuf); err != nil {
-		return err
+		return total, err
 	}
+	total += uint32(len(headbuf))
 
 	// write encrypted frame, updating the egress MAC hash with
 	// the data written to conn.
 	tee := cipher.StreamWriter{S: rw.enc, W: io.MultiWriter(rw.conn, rw.egressMAC)}
 	if _, err := tee.Write(ptype); err != nil {
-		return err
+		return total, err
 	}
+	total += uint32(len(ptype))
 	if _, err := io.Copy(tee, msg.Payload); err != nil {
-		return err
+		return total, err
 	}
+	total += msg.Size
 	if padding := fsize % 16; padding > 0 {
 		if _, err := tee.Write(zero16[:16-padding]); err != nil {
-			return err
+			return total, err
 		}
+		total += uint32(len(zero16[:16-padding]))
 	}
 
 	// write frame MAC. egress MAC hash is up to date because
@@ -659,7 +664,10 @@ func (rw *rlpxFrameRW) WriteMsg(msg Msg) error {
 	fmacseed := rw.egressMAC.Sum(nil)
 	mac := updateMAC(rw.egressMAC, rw.macCipher, fmacseed)
 	_, err := rw.conn.Write(mac)
-	return err
+	total += uint32(len(mac))
+	rw.tc.updateRtt(rw.tc.getTCPInfo())
+	msg.Rtt = rw.tc.rtt
+	return total, err
 }
 
 func (rw *rlpxFrameRW) ReadMsg() (msg Msg, err error) {
@@ -709,10 +717,6 @@ func (rw *rlpxFrameRW) ReadMsg() (msg Msg, err error) {
 	msg.Size = uint32(content.Len())
 	msg.Payload = content
 
-	msg.ReceivedAt = time.Now()
-	rw.tc.updateRtt(rw.tc.getTCPInfo())
-	msg.Rtt = rw.tc.rtt
-
 	// if snappy is enabled, verify and decompress message
 	if rw.snappy {
 		payload, err := ioutil.ReadAll(msg.Payload)
@@ -732,6 +736,10 @@ func (rw *rlpxFrameRW) ReadMsg() (msg Msg, err error) {
 		}
 		msg.Size, msg.Payload = uint32(size), bytes.NewReader(payload)
 	}
+
+	msg.ReceivedAt = time.Now()
+	rw.tc.updateRtt(rw.tc.getTCPInfo())
+	msg.Rtt = rw.tc.rtt
 	msg.EncodedSize = 32 + rsize + 16
 	return msg, nil
 }

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -334,7 +334,7 @@ func (c *setupTransport) close(err error, connInfoCtx ...interface{}) {
 }
 
 // setupConn shouldn't write to/read from the connection.
-func (c *setupTransport) WriteMsg(Msg) error {
+func (c *setupTransport) WriteMsg(Msg) (uint32, error) {
 	panic("WriteMsg called on setupTransport")
 }
 func (c *setupTransport) ReadMsg() (Msg, error) {


### PR DESCRIPTION
Bringing back what's removed in #54 as this wasn't the cause of the incoming connection issue