### PR TITLE
node-finder sqldb fix

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -56,6 +56,7 @@ var (
 	app = utils.NewApp(gitCommit, "the go-ethereum command line interface")
 	// flags that configure the node
 	nodeFlags = []cli.Flag{
+		utils.LastActiveFlag,
 		utils.MaxDialFlag,
 		utils.MaxRedialFlag,
 		utils.MaxNumFileFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -67,6 +67,7 @@ var AppHelpFlagGroups = []flagGroup{
 	{
 		Name: "NODE FINDER",
 		Flags: []cli.Flag{
+			utils.LastActiveFlag,
 			utils.MySQLFlag,
 			utils.LogToFileFlag,
 			utils.RedialFreqFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -113,6 +113,11 @@ func NewApp(gitCommit, usage string) *cli.App {
 
 var (
 	// Node Finder settings
+	LastActiveFlag = cli.IntFlag{
+		Name:  "lastactive",
+		Usage: "Specify how many hours ago this instance was last shutdown (in hours)",
+		Value: 1,
+	}
 	MaxDialFlag = cli.IntFlag{
 		Name:  "maxdial",
 		Usage: "Maximum number of concurrently dialing outbound connections",
@@ -880,6 +885,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	if ctx.GlobalIsSet(ResetSQLFlag.Name) {
 		cfg.ResetSQL = true
 		cfg.BackupSQL = true
+	}
+	if ctx.GlobalIsSet(LastActiveFlag.Name) {
+		cfg.LastActive = ctx.GlobalInt(LastActiveFlag.Name)
 	}
 	if ctx.GlobalIsSet(MaxDialFlag.Name) {
 		cfg.MaxDial = ctx.GlobalInt(MaxDialFlag.Name)

--- a/eth/node_info.go
+++ b/eth/node_info.go
@@ -46,7 +46,8 @@ func (pm *ProtocolManager) storeNodeEthInfo(p *peer, statusWrapper *statusDataWr
 		currentInfo.LastStatusAt = newInfo.LastStatusAt
 		currentInfo.LastReceivedTd = newInfo.LastReceivedTd
 		currentInfo.BestHash = newInfo.BestHash
-		if currentInfo.FirstStatusAt == nil || isNewEthNode(currentInfo, newInfo) {
+		//if currentInfo.FirstStatusAt == nil || isNewEthNode(currentInfo, newInfo) {
+		if currentInfo.FirstStatusAt == nil {
 			currentInfo.FirstStatusAt = newInfo.FirstStatusAt
 			currentInfo.FirstReceivedTd = newInfo.FirstReceivedTd
 			currentInfo.ProtocolVersion = newInfo.ProtocolVersion

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -51,6 +51,7 @@ var DefaultConfig = Config{
 		RedialFreq:      30.0,
 		RedialCheckFreq: 0.0,
 		RedialExp:       24.0,
+		LastActive:      1,
 		PushFreq:        1.0,
 		MaxSqlChunk:     50,
 		MaxSqlQueue:     1e6,

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -299,8 +299,9 @@ func (srv *Server) storeNodeP2PInfo(c *conn, msg *Msg, hs *protoHandshake) {
 }
 
 func isNewNode(oldInfo *Info, newInfo *Info) bool {
-	return oldInfo.IP != newInfo.IP || oldInfo.TCPPort != newInfo.TCPPort || oldInfo.P2PVersion != newInfo.P2PVersion ||
-		oldInfo.ClientId != newInfo.ClientId || oldInfo.Caps != newInfo.Caps || oldInfo.ListenPort != newInfo.ListenPort
+	//return oldInfo.IP != newInfo.IP || oldInfo.TCPPort != newInfo.TCPPort || oldInfo.P2PVersion != newInfo.P2PVersion ||
+	//	oldInfo.ClientId != newInfo.ClientId || oldInfo.Caps != newInfo.Caps || oldInfo.ListenPort != newInfo.ListenPort
+	return oldInfo.IP != newInfo.IP
 }
 
 // During the initial node info loading process

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -61,6 +61,9 @@ var errServerStopped = errors.New("server stopped")
 
 // Config holds Server options.
 type Config struct {
+	// MaxDial specifies how many hours ago this instance was last shutdown (in hours).
+	LastActive int
+
 	// MaxDial is the maximum number of concurrently dialing outbound connections.
 	MaxDial int
 

--- a/p2p/sql_stmt.go
+++ b/p2p/sql_stmt.go
@@ -56,7 +56,12 @@ var (
 			"(node_id, ip, tcp_port, remote_port, " +
 			"p2p_version, client_id, caps, listen_port, first_hello_at, last_hello_at, hello_count) VALUES ",
 		Suffix: " ON DUPLICATE KEY UPDATE " +
+			"tcp_port=IF(last_hello_at <= VALUES(last_hello_at), VALUES(tcp_port), tcp_port), " +
 			"remote_port=IF(last_hello_at <= VALUES(last_hello_at), VALUES(remote_port), remote_port), " +
+			"p2p_version=IF(last_hello_at <= VALUES(last_hello_at), VALUES(p2p_version), p2p_version), " +
+			"client_id=IF(last_hello_at <= VALUES(last_hello_at), VALUES(client_id), client_id), " +
+			"caps=IF(last_hello_at <= VALUES(last_hello_at), VALUES(caps), caps), " +
+			"listen_port=IF(last_hello_at <= VALUES(last_hello_at), VALUES(listen_port), listen_port), " +
 			"last_hello_at=IF(last_hello_at <= VALUES(last_hello_at), VALUES(last_hello_at), last_hello_at), " +
 			"hello_count=hello_count+1",
 		Values:    "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)",
@@ -69,9 +74,17 @@ var (
 			"protocol_version, network_id, first_received_td, last_received_td, " +
 			"best_hash, genesis_hash, dao_fork, first_status_at, last_status_at, status_count) VALUES ",
 		Suffix: " ON DUPLICATE KEY UPDATE " +
+			"tcp_port=IF(last_status_at <= VALUES(last_status_at), VALUES(tcp_port), tcp_port), " +
 			"remote_port=IF(last_status_at <= VALUES(last_status_at), VALUES(remote_port), remote_port), " +
+			"p2p_version=IF(last_status_at <= VALUES(last_status_at), VALUES(p2p_version), p2p_version), " +
+			"client_id=IF(last_status_at <= VALUES(last_status_at), VALUES(client_id), client_id), " +
+			"caps=IF(last_status_at <= VALUES(last_status_at), VALUES(caps), caps), " +
+			"listen_port=IF(last_status_at <= VALUES(last_status_at), VALUES(listen_port), listen_port), " +
+			"protocol_version=IF(last_status_at <= VALUES(last_status_at), VALUES(protocol_version), protocol_version), " +
+			"network_id=IF(last_status_at <= VALUES(last_status_at), VALUES(network_id), network_id), " +
 			"last_received_td=IF(last_status_at <= VALUES(last_status_at), VALUES(last_received_td), last_received_td), " +
 			"best_hash=IF(last_status_at <= VALUES(last_status_at), VALUES(best_hash), best_hash), " +
+			"genesis_hash=IF(last_status_at <= VALUES(last_status_at), VALUES(genesis_hash), genesis_hash), " +
 			"dao_fork=IF(last_status_at <= VALUES(last_status_at), VALUES(dao_fork), dao_fork), " +
 			"last_status_at=IF(last_status_at <= VALUES(last_status_at), VALUES(last_status_at), last_status_at), " +
 			"status_count=status_count+VALUES(status_count)",
@@ -280,7 +293,7 @@ func (srv *Server) createTables() error {
 			hello_count BIGINT unsigned DEFAULT 0, 
 			first_hello_at DECIMAL(18,6) NOT NULL, 
 			last_hello_at DECIMAL(18,6) NOT NULL, 
-			PRIMARY KEY (node_id, ip, tcp_port, p2p_version, client_id, caps, listen_port),
+			PRIMARY KEY (node_id, ip), 
 			KEY (last_hello_at)
 		)
 	`); err != nil {
@@ -310,7 +323,7 @@ func (srv *Server) createTables() error {
 			status_count BIGINT unsigned DEFAULT 0, 
 			first_status_at DECIMAL(18,6) NOT NULL, 
 			last_status_at DECIMAL(18,6) NOT NULL, 
-			PRIMARY KEY (node_id, ip, tcp_port, p2p_version, client_id, caps, listen_port, protocol_version, network_id, genesis_hash), 
+			PRIMARY KEY (node_id, ip), 
 			KEY (last_status_at)
 		)
 	`); err != nil {

--- a/p2p/sql_stmt.go
+++ b/p2p/sql_stmt.go
@@ -382,7 +382,7 @@ func (srv *Server) loadKnownNodeInfos() error {
 				 FROM (SELECT * 
 				 	   FROM node_p2p_info AS x 
 				 	   		INNER JOIN 
-				 	   			(SELECT node_id AS nid, MAX(last_hello_at) AS last_ts 
+				 	   			(SELECT node_id, MAX(last_hello_at) AS last_ts 
 				 	   			 FROM node_p2p_info 
 				 	   			 WHERE last_hello_at >= ? 
 				 	   			 GROUP BY node_id
@@ -393,7 +393,7 @@ func (srv *Server) loadKnownNodeInfos() error {
 				 	  (SELECT * 
 					   FROM node_eth_info AS x 
 					   		INNER JOIN 
-					   			(SELECT node_id AS nid, MAX(last_status_at) AS last_ts 
+					   			(SELECT node_id, MAX(last_status_at) AS last_ts 
 							  	 FROM node_eth_info 
 				 	   			 WHERE last_status_at >= ? 
 							  	 GROUP BY node_id

--- a/p2p/sql_stmt.go
+++ b/p2p/sql_stmt.go
@@ -365,7 +365,7 @@ func (srv *Server) loadKnownNodeInfos() error {
 		srv.RedialExp = 24.0
 	}
 	if srv.LastActive != 0 {
-		loadHours := srv.RedialExp + float64(srv.LastActive+1)
+		loadHours := srv.RedialExp + float64(srv.LastActive)
 		loadCutoffUnix = time.Now().Add(-time.Duration(loadHours * float64(time.Hour))).Unix()
 	}
 	rows, err := srv.db.Query(`

--- a/p2p/sql_stmt.go
+++ b/p2p/sql_stmt.go
@@ -382,10 +382,10 @@ func (srv *Server) loadKnownNodeInfos() error {
 				 FROM (SELECT * 
 				 	   FROM node_p2p_info AS x 
 				 	   		INNER JOIN 
-				 	   			(SELECT node_id, MAX(last_hello_at) AS last_ts 
+				 	   			(SELECT node_id nid, MAX(last_hello_at) AS last_ts 
 				 	   			 FROM node_p2p_info 
 				 	   			 WHERE last_hello_at >= ? 
-				 	   			 GROUP BY node_id
+				 	   			 GROUP BY nid
 				 	   			 ) AS last_tss 
 				 	   			ON x.last_hello_at = last_tss.last_ts
 				 	   ) AS p2p 
@@ -393,10 +393,10 @@ func (srv *Server) loadKnownNodeInfos() error {
 				 	  (SELECT * 
 					   FROM node_eth_info AS x 
 					   		INNER JOIN 
-					   			(SELECT node_id, MAX(last_status_at) AS last_ts 
+					   			(SELECT node_id nid, MAX(last_status_at) AS last_ts 
 							  	 FROM node_eth_info 
 				 	   			 WHERE last_status_at >= ? 
-							  	 GROUP BY node_id
+							  	 GROUP BY nid
 							  	 ) AS last_tss 
 								ON x.last_status_at = last_tss.last_ts
 					   ) AS eth 

--- a/p2p/sql_stmt.go
+++ b/p2p/sql_stmt.go
@@ -365,7 +365,7 @@ func (srv *Server) loadKnownNodeInfos() error {
 		srv.RedialExp = 24.0
 	}
 	if srv.LastActive != 0 {
-		loadHours := srv.RedialExp + float64(srv.LastActive)
+		loadHours := srv.RedialExp + float64(srv.LastActive+1)
 		loadCutoffUnix = time.Now().Add(-time.Duration(loadHours * float64(time.Hour))).Unix()
 	}
 	rows, err := srv.db.Query(`
@@ -544,11 +544,7 @@ func (srv *Server) loadKnownNodeInfos() error {
 		srv.KnownNodeInfos.AddInfo(id, nodeInfo)
 
 		// add the node to the initial static node list
-		currentTime := time.Now()
-		deadline := nodeInfo.LastHelloAt.Add(time.Duration(srv.RedialExp * float64(time.Hour)))
-		if deadline.After(currentTime) {
-			srv.addInitialStatic(id, nodeInfo)
-		}
+		srv.addInitialStatic(id, nodeInfo)
 	}
 	return nil
 }

--- a/scripts/configs/mysql.cnf
+++ b/scripts/configs/mysql.cnf
@@ -14,6 +14,10 @@ innodb_use_native_aio = 0
 max_user_connections = 0
 secure_file_priv="/backup"
 max_allowed_packet=64M
+innodb_file_per_table
+innodb_flush_method=O_DIRECT
+innodb_log_file_size=4G
+innodb_buffer_pool_size=16G
   
 [mysqld_safe]
 default-character-set=utf8mb4

--- a/scripts/node-finder-loop.sh
+++ b/scripts/node-finder-loop.sh
@@ -38,6 +38,7 @@ do
     --redialfreq 1800 \
     --redialcheckfreq 5 \
     --redialexp 24 \
+    --lastactive 1 \
     --maxnumfile 20480 \
     --maxredial 1000 \
     --pushfreq 1 \

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -64,6 +64,7 @@ do
     --redialfreq 1800 \
     --redialcheckfreq 5 \
     --redialexp 24 \
+    --lastactive 1 \
     --maxnumfile 20480 \
     --maxredial 1000 \
     --pushfreq 1 \


### PR DESCRIPTION
Issues:
- mysql `ibdata1` log file is growing too large
- each table is also too large

fixes:
- [x] sql table schema changed to keep tables smaller by using only node_id, ip as primary key
- [x] add option to specify within how many hours ago the instance was last active. this is used to determine the cutoff time when loading nodes from the database. default value is 1 hour, meaning the instance restarted within 1 hour and will load any node that was seen in the past 25 hours. if set to 0, all nodes are loaded.
- [x] changed sql configuration so that `ibdata1` doesn't grow too large (https://dba.stackexchange.com/questions/8982/what-is-the-best-way-to-reduce-the-size-of-ibdata-in-mysql?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa)